### PR TITLE
Add support for terraform import

### DIFF
--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -37,4 +37,10 @@ resource "tailscale_acl" "sample_acl" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_acl.sample_acl acl
+```

--- a/docs/resources/device_authorization.md
+++ b/docs/resources/device_authorization.md
@@ -35,4 +35,10 @@ resource "tailscale_device_authorization" "sample_authorization" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_device_authorization.sample_authorization "<device_name>"
+```

--- a/docs/resources/device_key.md
+++ b/docs/resources/device_key.md
@@ -13,12 +13,12 @@ The device_key resource allows you to update the properties of a device's key
 ## Example Usage
 
 ```terraform
-data "tailscale_device" "example_device" {
+data "tailscale_device" "sample_device" {
   name = "device.example.com"
 }
 
-resource "tailscale_device_key" "example_key" {
-  device_id           = data.tailscale_device.example_device.id
+resource "tailscale_device_key" "sample_key" {
+  device_id           = data.tailscale_device.sample_device.id
   key_expiry_disabled = true
 }
 ```
@@ -32,10 +32,16 @@ resource "tailscale_device_key" "example_key" {
 
 ### Optional
 
-- `key_expiry_disabled` (Boolean) Determines whether or not the device's key will expire
+- `key_expiry_disabled` (Boolean) Determines whether the device's key will expire
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_device_key.sample_key "<device_name>"
+```

--- a/docs/resources/device_subnet_routes.md
+++ b/docs/resources/device_subnet_routes.md
@@ -39,4 +39,10 @@ resource "tailscale_device_subnet_routes" "sample_routes" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_device_subnet_routes.sample_routes "<device_name>"
+```

--- a/docs/resources/device_tags.md
+++ b/docs/resources/device_tags.md
@@ -35,4 +35,10 @@ resource "tailscale_device_tags" "sample_tags" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_device_tags.sample_tags "<device_name>"
+```

--- a/docs/resources/dns_nameservers.md
+++ b/docs/resources/dns_nameservers.md
@@ -32,4 +32,10 @@ resource "tailscale_dns_nameservers" "sample_nameservers" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_dns_nameservers.sample_nameservers nameservers
+```

--- a/docs/resources/dns_preferences.md
+++ b/docs/resources/dns_preferences.md
@@ -29,4 +29,10 @@ resource "tailscale_dns_preferences" "sample_preferences" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_dns_preferences.sample_preferences dns_preferences
+```

--- a/docs/resources/dns_search_paths.md
+++ b/docs/resources/dns_search_paths.md
@@ -31,4 +31,10 @@ resource "tailscale_dns_search_paths" "sample_search_paths" {
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tailscale_dns_search_paths.sample_search_paths dns_search_paths
+```

--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -35,4 +35,12 @@ resource "tailscale_tailnet_key" "sample_key" {
 - `id` (String) The ID of this resource.
 - `key` (String, Sensitive) The authentication key
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Key identifiers can be found in the Tailscale admin panel. Importing a key will not include the sensitive key
+# data.
+terraform import tailscale_tailnet_key.sample_key "<key_id>"
+```

--- a/examples/resources/tailscale_acl/import.sh
+++ b/examples/resources/tailscale_acl/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_acl.sample_acl acl

--- a/examples/resources/tailscale_device_authorization/import.sh
+++ b/examples/resources/tailscale_device_authorization/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_device_authorization.sample_authorization "<device_name>"

--- a/examples/resources/tailscale_device_key/import.sh
+++ b/examples/resources/tailscale_device_key/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_device_key.sample_key "<device_name>"

--- a/examples/resources/tailscale_device_key/resource.tf
+++ b/examples/resources/tailscale_device_key/resource.tf
@@ -1,8 +1,8 @@
-data "tailscale_device" "example_device" {
+data "tailscale_device" "sample_device" {
   name = "device.example.com"
 }
 
-resource "tailscale_device_key" "example_key" {
-  device_id           = data.tailscale_device.example_device.id
+resource "tailscale_device_key" "sample_key" {
+  device_id           = data.tailscale_device.sample_device.id
   key_expiry_disabled = true
 }

--- a/examples/resources/tailscale_device_subnet_routes/import.sh
+++ b/examples/resources/tailscale_device_subnet_routes/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_device_subnet_routes.sample_routes "<device_name>"

--- a/examples/resources/tailscale_device_tags/import.sh
+++ b/examples/resources/tailscale_device_tags/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_device_tags.sample_tags "<device_name>"

--- a/examples/resources/tailscale_dns_nameservers/import.sh
+++ b/examples/resources/tailscale_dns_nameservers/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_dns_nameservers.sample_nameservers nameservers

--- a/examples/resources/tailscale_dns_preferences/import.sh
+++ b/examples/resources/tailscale_dns_preferences/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_dns_preferences.sample_preferences dns_preferences

--- a/examples/resources/tailscale_dns_search_paths/import.sh
+++ b/examples/resources/tailscale_dns_search_paths/import.sh
@@ -1,0 +1,1 @@
+terraform import tailscale_dns_search_paths.sample_search_paths dns_search_paths

--- a/examples/resources/tailscale_tailnet_key/import.sh
+++ b/examples/resources/tailscale_tailnet_key/import.sh
@@ -1,0 +1,3 @@
+# Key identifiers can be found in the Tailscale admin panel. Importing a key will not include the sensitive key
+# data.
+terraform import tailscale_tailnet_key.sample_key "<key_id>"

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -22,6 +22,9 @@ func resourceACL() *schema.Resource {
 		CreateContext: resourceACLCreate,
 		UpdateContext: resourceACLUpdate,
 		DeleteContext: resourceACLDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"acl": {
 				Type:             schema.TypeString,
@@ -81,7 +84,7 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diagnosticsError(err, "Failed to unmarshal ACL")
 	}
 
-	if err := client.SetACL(ctx, acl); err != nil {
+	if err = client.SetACL(ctx, acl); err != nil {
 		return diagnosticsError(err, "Failed to set ACL")
 	}
 
@@ -102,7 +105,7 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diagnosticsError(err, "Failed to unmarshal ACL")
 	}
 
-	if err := client.SetACL(ctx, acl); err != nil {
+	if err = client.SetACL(ctx, acl); err != nil {
 		return diagnosticsError(err, "Failed to set ACL")
 	}
 

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -16,6 +16,9 @@ func resourceDeviceAuthorization() *schema.Resource {
 		CreateContext: resourceDeviceAuthorizationCreate,
 		UpdateContext: resourceDeviceAuthorizationUpdate,
 		DeleteContext: resourceDeviceAuthorizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: importWithDeviceIDFromName,
+		},
 		Schema: map[string]*schema.Schema{
 			"device_id": {
 				Type:        schema.TypeString,

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -16,6 +16,9 @@ func resourceDeviceKey() *schema.Resource {
 		CreateContext: resourceDeviceKeyCreate,
 		DeleteContext: resourceDeviceKeyDelete,
 		UpdateContext: resourceDeviceKeyUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: importWithDeviceIDFromName,
+		},
 		Schema: map[string]*schema.Schema{
 			"device_id": {
 				Type:        schema.TypeString,
@@ -25,7 +28,7 @@ func resourceDeviceKey() *schema.Resource {
 			"key_expiry_disabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Determines whether or not the device's key will expire",
+				Description: "Determines whether the device's key will expire",
 			},
 		},
 	}

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -16,6 +16,9 @@ func resourceDeviceSubnetRoutes() *schema.Resource {
 		CreateContext: resourceDeviceSubnetRoutesCreate,
 		UpdateContext: resourceDeviceSubnetRoutesUpdate,
 		DeleteContext: resourceDeviceSubnetRoutesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: importWithDeviceIDFromName,
+		},
 		Schema: map[string]*schema.Schema{
 			"device_id": {
 				Type:        schema.TypeString,

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -16,6 +16,9 @@ func resourceDeviceTags() *schema.Resource {
 		CreateContext: resourceDeviceTagsCreate,
 		UpdateContext: resourceDeviceTagsUpdate,
 		DeleteContext: resourceDeviceTagsDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: importWithDeviceIDFromName,
+		},
 		Schema: map[string]*schema.Schema{
 			"device_id": {
 				Type:        schema.TypeString,

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -16,6 +16,9 @@ func resourceDNSNameservers() *schema.Resource {
 		CreateContext: resourceDNSNameserversCreate,
 		UpdateContext: resourceDNSNameserversUpdate,
 		DeleteContext: resourceDNSNameserversDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"nameservers": {
 				Type: schema.TypeList,

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -16,6 +16,9 @@ func resourceDNSPreferences() *schema.Resource {
 		CreateContext: resourceDNSPreferencesCreate,
 		UpdateContext: resourceDNSPreferencesUpdate,
 		DeleteContext: resourceDNSPreferencesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"magic_dns": {
 				Type:        schema.TypeBool,

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -16,6 +16,9 @@ func resourceDNSSearchPaths() *schema.Resource {
 		UpdateContext: resourceDNSSearchPathsUpdate,
 		DeleteContext: resourceDNSSearchPathsDelete,
 		CreateContext: resourceDNSSearchPathsCreate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"search_paths": {
 				Type: schema.TypeList,

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -15,6 +15,9 @@ func resourceTailnetKey() *schema.Resource {
 		ReadContext:   resourceTailnetKeyRead,
 		CreateContext: resourceTailnetKeyCreate,
 		DeleteContext: resourceTailnetKeyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"reusable": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
This commit is an initial attempt to set up support for the `terraform import`
command. It includes the default fallthrough importer for global resources
such as the ACL, DNS preferences etc.

For device-specific resources, the name of the device can be provided which
will be resolved to a device identifier. The device identifier is then
added to the resource so that a refresh will include it.

Signed-off-by: David Bond <davidsbond93@gmail.com>
