### PR TITLE
README: update description to maintained by Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # terraform-provider-tailscale 
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/davidsbond/terraform-provider-tailscale.svg)](https://pkg.go.dev/github.com/davidsbond/terraform-provider-tailscale)
-[![Go Report Card](https://goreportcard.com/badge/github.com/davidsbond/terraform-provider-tailscale)](https://goreportcard.com/report/github.com/davidsbond/terraform-provider-tailscale)
-![Github Actions](https://github.com/davidsbond/terraform-provider-tailscale/actions/workflows/ci.yml/badge.svg?branch=master)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tailscale/terraform-provider-tailscale.svg)](https://pkg.go.dev/github.com/tailscale/terraform-provider-tailscale)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tailscale/terraform-provider-tailscale)](https://goreportcard.com/report/github.com/tailscale/terraform-provider-tailscale)
+![Github Actions](https://github.com/tailscale/terraform-provider-tailscale/actions/workflows/ci.yml/badge.svg?branch=master)
 
-This repository contains the source code for the [Terraform Tailscale Provider](https://registry.terraform.io/providers/davidsbond/tailscale) 
-a Terraform provider implementation for interacting with the [Tailscale](https://tailscale.com) API.
+This repository contains the source code for the [Tailscale Terraform provider](https://registry.terraform.io/providers/davidsbond/tailscale). This Terraform provider lets you interact with the [Tailscale](https://tailscale.com) API.
 
 See the [documentation](https://registry.terraform.io/providers/davidsbond/tailscale/latest/docs) in the Terraform registry
 for the most up-to-date information and latest release.
 
-This provider is unofficial and not affiliated in any way with the team at Tailscale. I've been given thanks for creating 
-it, but do not expect anyone who actually works at Tailscale to help you with problems regarding this provider.
+This provider is maintained by Tailscale. Thanks to everyone who contributed to the development of the Tailscale Terraform provider, and special thanks to [davidsbond](https://github.com/davidsbond).
 
 ## Getting Started
 
@@ -49,5 +47,5 @@ provider "tailscale" {
 ## Contributing
 
 Please review the [contributing guidelines](./CONTRIBUTING.md) and [code of conduct](.github/CODE_OF_CONDUCT.md) before
-contributing to this codebase. Please create a [new issue](https://github.com/davidsbond/terraform-provider-tailscale/issues/new/choose) 
+contributing to this codebase. Please create a [new issue](https://github.com/tailscale/terraform-provider-tailscale/issues/new/choose) 
 for bugs and feature requests and fill in as much detail as you can.


### PR DESCRIPTION
**What this PR does / why we need it**: Updates repo description to clarify it is maintained by Tailscale
Did not update references to Terraform provider in new namespace, which is not published yet.

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a

Fixes #

**Special notes for your reviewer**:
