### PR TITLE
update module name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Format code
         run: |
           go fmt ./...
-          goimports -w -local github.com/davidsbond .
+          goimports -w -local github.com/tailscale .
 
       - name: Check for uncommitted changes
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ advice.
 
 ## Raising Issues
 
-Please use the GitHub [issues](https://github.com/davidsbond/terraform-provider-tailscale/issues/new/choose) tab to create a new issue, 
+Please use the GitHub [issues](https://github.com/tailscale/terraform-provider-tailscale/issues/new/choose) tab to create a new issue, 
 choosing an appropriate category from the list available.
 
 This terraform provider is limited by the functionality available in the [Tailscale API](https://github.com/tailscale/tailscale/blob/main/api.md),

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com
-NAMESPACE=davidsbond
+NAMESPACE=tailscale
 NAME=tailscale
 BINARY=terraform-provider-${NAME}
 VERSION=0.1
@@ -38,4 +38,4 @@ testacc:
 
 format:
 	go fmt ./...
-	goimports -w -local github.com/davidsbond .
+	goimports -w -local github.com/tailscale .

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # terraform-provider-tailscale 
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/davidsbond/terraform-provider-tailscale.svg)](https://pkg.go.dev/github.com/davidsbond/terraform-provider-tailscale)
-[![Go Report Card](https://goreportcard.com/badge/github.com/davidsbond/terraform-provider-tailscale)](https://goreportcard.com/report/github.com/davidsbond/terraform-provider-tailscale)
-![Github Actions](https://github.com/davidsbond/terraform-provider-tailscale/actions/workflows/ci.yml/badge.svg?branch=master)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tailscale/terraform-provider-tailscale.svg)](https://pkg.go.dev/github.com/tailscale/terraform-provider-tailscale)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tailscale/terraform-provider-tailscale)](https://goreportcard.com/report/github.com/tailscale/terraform-provider-tailscale)
+![Github Actions](https://github.com/tailscale/terraform-provider-tailscale/actions/workflows/ci.yml/badge.svg?branch=master)
 
-This repository contains the source code for the [Terraform Tailscale Provider](https://registry.terraform.io/providers/davidsbond/tailscale) 
+This repository contains the source code for the [Terraform Tailscale Provider](https://registry.terraform.io/providers/tailscale/tailscale) 
 a Terraform provider implementation for interacting with the [Tailscale](https://tailscale.com) API.
 
-See the [documentation](https://registry.terraform.io/providers/davidsbond/tailscale/latest/docs) in the Terraform registry
+See the [documentation](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs) in the Terraform registry
 for the most up-to-date information and latest release.
 
 This provider is unofficial and not affiliated in any way with the team at Tailscale. I've been given thanks for creating 
@@ -21,7 +21,7 @@ To install this provider, copy and paste this code into your Terraform configura
 terraform {
   required_providers {
     tailscale = {
-      source = "davidsbond/tailscale"
+      source = "tailscale/tailscale"
       version = "0.2.0"
     }
   }
@@ -49,5 +49,5 @@ provider "tailscale" {
 ## Contributing
 
 Please review the [contributing guidelines](./CONTRIBUTING.md) and [code of conduct](.github/CODE_OF_CONDUCT.md) before
-contributing to this codebase. Please create a [new issue](https://github.com/davidsbond/terraform-provider-tailscale/issues/new/choose) 
+contributing to this codebase. Please create a [new issue](https://github.com/tailscale/terraform-provider-tailscale/issues/new/choose) 
 for bugs and feature requests and fill in as much detail as you can.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ description: |-
 terraform {
   required_providers {
     tailscale = {
-      source  = "davidsbond/tailscale"
+      source  = "tailscale/tailscale"
       version = "<version>"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tailscale = {
-      source  = "davidsbond/tailscale"
+      source  = "tailscale/tailscale"
       version = "<version>"
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/davidsbond/terraform-provider-tailscale
+module github.com/tailscale/terraform-provider-tailscale
 
-go 1.18
+go 1.19
 
 require (
-	github.com/davidsbond/tailscale-client-go v1.5.0
 	github.com/google/go-cmp v0.5.8
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
@@ -11,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
+	github.com/tailscale/tailscale-client-go v1.6.0
 	golang.org/x/tools v0.1.11
 	inet.af/netaddr v0.0.0-20220811202034-502d2d690317
 	tailscale.com v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidsbond/tailscale-client-go v1.5.0 h1:FaWHMrgQ8GNZQhr181cxU5/kg9l62dLpKNPdJ9xiLB8=
-github.com/davidsbond/tailscale-client-go v1.5.0/go.mod h1:77+YKI2VhoJcq0bJzBzY7Yj/yMTUcGR4tKm/hJDf08k=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
@@ -242,6 +240,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f h1:n4r/sJ92cBSBHK8n9lR1XLFr0OiTVeGfN5TR+9LaN7E=
 github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
+github.com/tailscale/tailscale-client-go v1.6.0 h1:ZyJfRxhvTGNRvG5fQie1SEld4W4oJ9wuDa+Oja4mfBE=
+github.com/tailscale/tailscale-client-go v1.6.0/go.mod h1:yJRyNe2PoUgMw92N37oHGgKTODN4oIsdvb/ykRY+OtQ=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/davidsbond/terraform-provider-tailscale/tailscale"
+	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 func main() {

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func dataSourceDevice() *schema.Resource {

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func dataSourceDevices() *schema.Resource {

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 type ProviderOption func(p *schema.Provider)

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	ts "github.com/davidsbond/tailscale-client-go/tailscale"
-	"github.com/davidsbond/terraform-provider-tailscale/tailscale"
+	ts "github.com/tailscale/tailscale-client-go/tailscale"
+	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 var testClient *ts.Client

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -10,9 +10,10 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/tailscale/hujson"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceACL() *schema.Resource {
@@ -142,7 +143,7 @@ func unmarshalACL(s string) (tailscale.ACL, error) {
 	if err = decoder.Decode(&acl); err != nil {
 		return acl, fmt.Errorf("%w. (This error may be caused by a new ACL feature that is not yet supported by "+
 			"this terraform provider. If you're using a valid ACL field, please raise an issue at "+
-			"https://github.com/davidsbond/terraform-provider-tailscale/issues/new/choose)", err)
+			"https://github.com/tailscale/terraform-provider-tailscale/issues/new/choose)", err)
 	}
 
 	return acl, nil

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDeviceAuthorization() *schema.Resource {

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 const testDeviceAuthorization = `

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDeviceKey() *schema.Resource {

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 const testDeviceKey = `

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDeviceSubnetRoutes() *schema.Resource {

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 const testDeviceSubnetRoutes = `

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -3,10 +3,10 @@ package tailscale
 import (
 	"context"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDeviceTags() *schema.Resource {

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 const testDeviceTags = `

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDNSNameservers() *schema.Resource {

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDNSPreferences() *schema.Resource {

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDNSSearchPaths() *schema.Resource {

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceTailnetKey() *schema.Resource {

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 const testTailnetKey = `

--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 type TestServer struct {


### PR DESCRIPTION
Also:
- switch to go 1.19
- go mod tidy

Signed-off-by: Denton Gentry <dgentry@tailscale.com>

**What this PR does / why we need it**:
renames module from davidsbond namespace to tailscale (thank you, David!)

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #141

**Special notes for your reviewer**:
