### PR TITLE
resource_device_authorization: update delete

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -113,6 +113,13 @@ func resourceDeviceAuthorizationUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceDeviceAuthorizationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	// Since authorization cannot be removed at this point, deleting the resource will do nothing.
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	// when the device_authorization resource is deleted, delete the device
+	if err := client.DeleteDevice(ctx, deviceID); err != nil {
+		return diagnosticsError(err, "Failed to delete device")
+	}
+
 	return nil
 }


### PR DESCRIPTION
deletes the device on authorization resouce deletion

**What this PR does / why we need it**: Ability to delete device with provider

**Which issue this PR fixes**: fixes #68
