### PR TITLE
Perform validation on ACL create/update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
-	github.com/tailscale/tailscale-client-go v1.6.0
+	github.com/tailscale/tailscale-client-go v1.6.1-0.20221010210317-4916933bdd36
 	golang.org/x/tools v0.1.12
 	tailscale.com v1.30.2
 )

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f h1:n4r/sJ92cBSBHK
 github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/tailscale/tailscale-client-go v1.6.0 h1:ZyJfRxhvTGNRvG5fQie1SEld4W4oJ9wuDa+Oja4mfBE=
 github.com/tailscale/tailscale-client-go v1.6.0/go.mod h1:yJRyNe2PoUgMw92N37oHGgKTODN4oIsdvb/ykRY+OtQ=
+github.com/tailscale/tailscale-client-go v1.6.1-0.20221010210317-4916933bdd36 h1:fE7V3uW0kDCvCC384HV6nb5e703cnPzp/RDEe38+8pk=
+github.com/tailscale/tailscale-client-go v1.6.1-0.20221010210317-4916933bdd36/go.mod h1:yJRyNe2PoUgMw92N37oHGgKTODN4oIsdvb/ykRY+OtQ=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -82,7 +82,13 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diagnosticsError(err, "Failed to unmarshal ACL")
 	}
 
-	if err := client.SetACL(ctx, acl); err != nil {
+	if len(acl.Tests) > 0 {
+		if err = client.ValidateACL(ctx, acl); err != nil {
+			return diagnosticsError(err, "Failed to validate ACL")
+		}
+	}
+
+	if err = client.SetACL(ctx, acl); err != nil {
 		return diagnosticsError(err, "Failed to set ACL")
 	}
 
@@ -103,7 +109,13 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diagnosticsError(err, "Failed to unmarshal ACL")
 	}
 
-	if err := client.SetACL(ctx, acl); err != nil {
+	if len(acl.Tests) > 0 {
+		if err = client.ValidateACL(ctx, acl); err != nil {
+			return diagnosticsError(err, "Failed to validate ACL")
+		}
+	}
+
+	if err = client.SetACL(ctx, acl); err != nil {
 		return diagnosticsError(err, "Failed to set ACL")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit modifies the provider to validate ACLs against the Tailscale API on create or update. Validation will only be performed if the ACL definition has at least one test in it.

Signed-off-by: David Bond <davidsbond93@gmail.com>

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #158
