### PR TITLE
Update sample provider config for new registry path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     tailscale = {
       source = "tailscale/tailscale"
-      version = "0.2.0"
+      version = ">= 0.13.5"
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The old versions are still published under `davidsbond`, the `tailscale` registry path only has `>= 0.13.5`. Copying config from documentation will not work.

**Which issue this PR fixes**: 

Fixes #163

**Special notes for your reviewer**:
