### PR TITLE
Add key expiration to tailscale_tailnet_key

### DIFF
--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -17,6 +17,7 @@ resource "tailscale_tailnet_key" "sample_key" {
   reusable      = true
   ephemeral     = false
   preauthorized = true
+  expiry = 3600
 }
 ```
 
@@ -29,6 +30,7 @@ resource "tailscale_tailnet_key" "sample_key" {
 - `preauthorized` (Boolean) Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default.
 - `reusable` (Boolean) Indicates if the key is reusable or single-use.
 - `tags` (Set of String) List of tags to apply to the machines authenticated by the key.
+- `expiry` (Integer) Expiration of the key, in seconds.
 
 ### Read-Only
 

--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -17,6 +17,7 @@ resource "tailscale_tailnet_key" "sample_key" {
   reusable      = true
   ephemeral     = false
   preauthorized = true
+  expiry        = 3600
 }
 ```
 
@@ -26,6 +27,7 @@ resource "tailscale_tailnet_key" "sample_key" {
 ### Optional
 
 - `ephemeral` (Boolean) Indicates if the key is ephemeral.
+- `expiry` (Number) The expiry of the key in seconds
 - `preauthorized` (Boolean) Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default.
 - `reusable` (Boolean) Indicates if the key is reusable or single-use.
 - `tags` (Set of String) List of tags to apply to the machines authenticated by the key.

--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -17,7 +17,6 @@ resource "tailscale_tailnet_key" "sample_key" {
   reusable      = true
   ephemeral     = false
   preauthorized = true
-  expiry = 3600
 }
 ```
 
@@ -30,7 +29,6 @@ resource "tailscale_tailnet_key" "sample_key" {
 - `preauthorized` (Boolean) Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default.
 - `reusable` (Boolean) Indicates if the key is reusable or single-use.
 - `tags` (Set of String) List of tags to apply to the machines authenticated by the key.
-- `expiry` (Integer) Expiration of the key, in seconds.
 
 ### Read-Only
 

--- a/examples/resources/tailscale_tailnet_key/resource.tf
+++ b/examples/resources/tailscale_tailnet_key/resource.tf
@@ -2,5 +2,5 @@ resource "tailscale_tailnet_key" "sample_key" {
   reusable      = true
   ephemeral     = false
   preauthorized = true
-  expiry = 3600
+  expiry        = 3600
 }

--- a/examples/resources/tailscale_tailnet_key/resource.tf
+++ b/examples/resources/tailscale_tailnet_key/resource.tf
@@ -2,4 +2,5 @@ resource "tailscale_tailnet_key" "sample_key" {
   reusable      = true
   ephemeral     = false
   preauthorized = true
+  expiry = 3600
 }

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -49,6 +49,12 @@ func resourceTailnetKey() *schema.Resource {
 				Computed:    true,
 				Sensitive:   true,
 			},
+			"expiry": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The expiry of the key in seconds",
+				ForceNew:    true,
+			},
 		},
 	}
 }
@@ -58,6 +64,7 @@ func resourceTailnetKeyCreate(ctx context.Context, d *schema.ResourceData, m int
 	reusable := d.Get("reusable").(bool)
 	ephemeral := d.Get("ephemeral").(bool)
 	preauthorized := d.Get("preauthorized").(bool)
+	expiry := d.Get("expiry").(int)
 	var tags []string
 	for _, tag := range d.Get("tags").(*schema.Set).List() {
 		tags = append(tags, tag.(string))
@@ -68,6 +75,7 @@ func resourceTailnetKeyCreate(ctx context.Context, d *schema.ResourceData, m int
 	capabilities.Devices.Create.Ephemeral = ephemeral
 	capabilities.Devices.Create.Tags = tags
 	capabilities.Devices.Create.Preauthorized = preauthorized
+	capabilities.Devices.Create.Expiry = expiry
 
 	key, err := client.CreateKey(ctx, capabilities)
 	if err != nil {

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -15,6 +15,7 @@ const testTailnetKey = `
 		ephemeral = true
 		preauthorized = true
 		tags = ["tag:server"]
+		expiry = 3600
 	}
 `
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds key expiration option to the `tailscale_tailnet_key` resource

**Which issue this PR fixes** 
N/A

**Special notes for your reviewer**:
See https://github.com/tailscale/tailscale-client-go/pull/34 for associated client change

