### PR TITLE
tailscale_tailnet_key: correctly set key expiration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/stretchr/testify v1.8.1
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
-	github.com/tailscale/tailscale-client-go v1.7.0
+	github.com/tailscale/tailscale-client-go v1.8.0
 	golang.org/x/tools v0.3.0
 	tailscale.com v1.32.3
 )

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f h1:n4r/sJ92cBSBHK
 github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/tailscale/tailscale-client-go v1.7.0 h1:82XCfbZCDuuvZPwdPgG6x0MLlijzRTdIKLMggWxWylI=
 github.com/tailscale/tailscale-client-go v1.7.0/go.mod h1:vHy4QKSL+16KKl12Gfa3kf13lu/4lJjFINDsnzOCi/M=
+github.com/tailscale/tailscale-client-go v1.8.0 h1:fP6gu2p14XVYPKFxxD8EizkbxGs4pttpzZjpnz+kogM=
+github.com/tailscale/tailscale-client-go v1.8.0/go.mod h1:vHy4QKSL+16KKl12Gfa3kf13lu/4lJjFINDsnzOCi/M=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
This updates the client library to pick up tailscale/tailscale-client-go#37 and correctly passed key expiration time.

Closes #184.