### PR TITLE
Docs: Bump provider version in README to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     tailscale = {
       source = "tailscale/tailscale"
-      version = "0.13.5"
+      version = "0.13.6"
     }
   }
 }


### PR DESCRIPTION
Bump provider version in README to [latest available (v0.13.6)](https://github.com/tailscale/terraform-provider-tailscale/releases/tag/v0.13.6) as of December 1 2022.