### PR TITLE
Add `rotate_when_changed` to tailnet key schema

### DIFF
--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -56,6 +56,15 @@ func resourceTailnetKey() *schema.Resource {
 				Description: "The expiry of the key in seconds",
 				ForceNew:    true,
 			},
+			"rotate_when_changed": {
+				Description: "Arbitrary map of values that, when changed, will trigger rotation of the key.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new field to the schema of `tailscale_tailnet_key`, which would allow one to use the [`time_rotating`](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) without depending on the lifecycle.

So you could do this to auto rotate the key


```hcl
resource "time_rotating" "autorotator" {
  rotation_days = 60
}

resource "tailscale_tailnet_key" "tailscale_ingress" {
  reusable  = true
  ephemeral = true
  tags = [
    "tag:some-tag",
  ]
  rotate_when_changed = {
    rotator = time_rotating.autorotator.id
  }
}
```



**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #144

**Special notes for your reviewer**:
