### PR TITLE
tailscale_device_subnet_routes: Fix confusing error message

### DIFF
--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -40,7 +40,7 @@ func resourceDeviceSubnetRoutesRead(ctx context.Context, d *schema.ResourceData,
 
 	routes, err := client.DeviceSubnetRoutes(ctx, deviceID)
 	if err != nil {
-		return diagnosticsError(err, "Failed to fetch dns nameservers")
+		return diagnosticsError(err, "Failed to fetch device subnet routes")
 	}
 
 	if err = d.Set("routes", routes.Enabled); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The error message on `read` operations of `tailscale_device_subnet_routes` referred to name servers instead of device routes. This fixes the error message to refer to the correct resource type.

