### PR TITLE
Document defaults for `device_key` and `tailnet_key`

### DIFF
--- a/docs/resources/device_key.md
+++ b/docs/resources/device_key.md
@@ -32,7 +32,7 @@ resource "tailscale_device_key" "example_key" {
 
 ### Optional
 
-- `key_expiry_disabled` (Boolean) Determines whether or not the device's key will expire
+- `key_expiry_disabled` (Boolean) Determines whether or not the device's key will expire. Defaults to `false`.
 
 ### Read-Only
 

--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -27,11 +27,11 @@ resource "tailscale_tailnet_key" "sample_key" {
 
 ### Optional
 
-- `description` (String) A description of the key consisting of alphanumeric characters.
-- `ephemeral` (Boolean) Indicates if the key is ephemeral.
-- `expiry` (Number) The expiry of the key in seconds
-- `preauthorized` (Boolean) Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default.
-- `reusable` (Boolean) Indicates if the key is reusable or single-use.
+- `description` (String) A description of the key consisting of alphanumeric characters. Defaults to `""`.
+- `ephemeral` (Boolean) Indicates if the key is ephemeral. Defaults to `false`.
+- `expiry` (Number) The expiry of the key in seconds. Defaults to `7776000` (90 days).
+- `preauthorized` (Boolean) Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default. Defaults to `false`.
+- `reusable` (Boolean) Indicates if the key is reusable or single-use. Defaults to `false`.
 - `tags` (Set of String) List of tags to apply to the machines authenticated by the key.
 
 ### Read-Only

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -25,7 +25,7 @@ func resourceDeviceKey() *schema.Resource {
 			"key_expiry_disabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Determines whether or not the device's key will expire",
+				Description: "Determines whether or not the device's key will expire. Defaults to `false`.",
 			},
 		},
 	}

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -20,13 +20,13 @@ func resourceTailnetKey() *schema.Resource {
 			"reusable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Indicates if the key is reusable or single-use.",
+				Description: "Indicates if the key is reusable or single-use. Defaults to `false`.",
 				ForceNew:    true,
 			},
 			"ephemeral": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Indicates if the key is ephemeral.",
+				Description: "Indicates if the key is ephemeral. Defaults to `false`.",
 				ForceNew:    true,
 			},
 			"tags": {
@@ -41,7 +41,7 @@ func resourceTailnetKey() *schema.Resource {
 			"preauthorized": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default.",
+				Description: "Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default. Defaults to `false`.",
 				ForceNew:    true,
 			},
 			"key": {
@@ -53,7 +53,7 @@ func resourceTailnetKey() *schema.Resource {
 			"expiry": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The expiry of the key in seconds",
+				Description: "The expiry of the key in seconds. Defaults to `7776000` (90 days).",
 				ForceNew:    true,
 			},
 			"created_at": {
@@ -69,7 +69,7 @@ func resourceTailnetKey() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "A description of the key consisting of alphanumeric characters.",
+				Description: "A description of the key consisting of alphanumeric characters. Defaults to `\"\"`.",
 				ForceNew:    true,
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents the optional resource properties for `device_key` and `tailnet_key` resources.

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #291 

**Special notes for your reviewer**:
