### PR TITLE
Support importing tailscale_dns_preferences resources.

### DIFF
--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -36,3 +36,12 @@ resource "tailscale_acl" "sample_acl" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# ID doesn't matter.
+terraform import tailscale_acl.sample_acl acl
+```

--- a/docs/resources/dns_preferences.md
+++ b/docs/resources/dns_preferences.md
@@ -28,3 +28,12 @@ resource "tailscale_dns_preferences" "sample_preferences" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# ID doesn't matter.
+terraform import tailscale_dns_preferences.sample_preferences dns_preferences
+```

--- a/examples/resources/tailscale_acl/import.sh
+++ b/examples/resources/tailscale_acl/import.sh
@@ -1,0 +1,2 @@
+# ID doesn't matter.
+terraform import tailscale_acl.sample_acl acl

--- a/examples/resources/tailscale_dns_preferences/import.sh
+++ b/examples/resources/tailscale_dns_preferences/import.sh
@@ -1,0 +1,2 @@
+# ID doesn't matter.
+terraform import tailscale_dns_preferences.sample_preferences dns_preferences

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -16,6 +16,9 @@ func resourceDNSPreferences() *schema.Resource {
 		CreateContext: resourceDNSPreferencesCreate,
 		UpdateContext: resourceDNSPreferencesUpdate,
 		DeleteContext: resourceDNSPreferencesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"magic_dns": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Also document importing tailscale_acl resources, which was supported from #186.

Partially takes over #125, but only for a resource I'm actively testing. Others can follow in a future PR.

@clstokes @davidsbond 