### PR TITLE
Document that ACL tests are run when creating and updating tailscale_acl resources.

### DIFF
--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -4,11 +4,14 @@ page_title: "tailscale_acl Resource - terraform-provider-tailscale"
 subcategory: ""
 description: |-
   The acl resource allows you to configure a Tailscale ACL. See https://tailscale.com/kb/1018/acls for more information. Note that this resource will completely overwrite existing ACL contents for a given tailnet.
+  If tests are defined in the ACL (the top-level "tests" section), ACL validation will occur before creation and update operations are applied.
 ---
 
 # tailscale_acl (Resource)
 
 The acl resource allows you to configure a Tailscale ACL. See https://tailscale.com/kb/1018/acls for more information. Note that this resource will completely overwrite existing ACL contents for a given tailnet.
+
+If tests are defined in the ACL (the top-level "tests" section), ACL validation will occur before creation and update operations are applied.
 
 ## Example Usage
 

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -17,9 +17,13 @@ import (
 	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
+const resourceACLDescription = `The acl resource allows you to configure a Tailscale ACL. See https://tailscale.com/kb/1018/acls for more information. Note that this resource will completely overwrite existing ACL contents for a given tailnet.
+
+If tests are defined in the ACL (the top-level "tests" section), ACL validation will occur before creation and update operations are applied.`
+
 func resourceACL() *schema.Resource {
 	return &schema.Resource{
-		Description:   "The acl resource allows you to configure a Tailscale ACL. See https://tailscale.com/kb/1018/acls for more information. Note that this resource will completely overwrite existing ACL contents for a given tailnet.",
+		Description:   resourceACLDescription,
 		ReadContext:   resourceACLRead,
 		CreateContext: resourceACLCreate,
 		UpdateContext: resourceACLUpdate,


### PR DESCRIPTION
Fixes #158.
Closes #161.