### PR TITLE
validate the description length for tailnet keys

### DIFF
--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -74,6 +74,12 @@ func resourceTailnetKey() *schema.Resource {
 				Optional:    true,
 				Description: "A description of the key consisting of alphanumeric characters. Defaults to `\"\"`.",
 				ForceNew:    true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					if len(i.(string)) > 50 {
+						return diagnosticsError(nil, "description must be 50 characters or less")
+					}
+					return nil
+				},
 			},
 			"invalid": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION

**What this PR does / why we need it**:

This adds validation logic to the tailnet key resource to ensure the description doesn't exceed 50 characters

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 


Fixes #320

**Special notes for your reviewer**:
