### PR TITLE
tailscale: fix default User-Agent header to include terraform version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      - "-s -w -X github.com/tailscale/terraform-provider-tailscale/tailscale.providerVersion={{.Version}} -X main.commit={{.Commit}}"
     goos:
       - freebsd
       - windows

--- a/main.go
+++ b/main.go
@@ -8,24 +8,10 @@ import (
 	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
-// version is filled by goreleaser at build time.
-var version = "dev"
-
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
-			return tailscale.Provider(addUserAgent)
+			return tailscale.Provider()
 		},
 	})
-}
-
-// addUserAgent adds a `user_agent` configuration key to the provider with a
-// default value based on provider version.
-func addUserAgent(p *schema.Provider) {
-	p.Schema["user_agent"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Default:     p.UserAgent("terraform-provider-tailscale", version),
-		Optional:    true,
-		Description: "User-Agent header for API requests.",
-	}
 }


### PR DESCRIPTION
The `schema.Provider.UserAgent` helper function was previously being called at a point in the plugin lifecycle before the `TerraformVersion` for the provider was set by Terraform Core. This was resulting in the Terraform version information being missing from the User-Agent header. The call to `schema.Provider.UserAgent` has now been moved into the `providerConfigure` func as this is called later in the configure lifecycle where the Terraform version is properly set.

### Header Before
`Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.33.0 terraform-provider-tailscale/dev`

### Header After
`Terraform/1.8.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.33.0 terraform-provider-tailscale/dev`

Fixes https://github.com/tailscale/corp/issues/19630
