### PR TITLE
tailscale: update state after modification functions for resources

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -71,7 +71,7 @@ func resourceDeviceAuthorizationCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	d.SetId(deviceID)
-	return nil
+	return resourceDeviceAuthorizationRead(ctx, d, m)
 }
 
 func resourceDeviceAuthorizationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -109,7 +109,7 @@ func resourceDeviceAuthorizationUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	d.Set("authorized", true)
-	return nil
+	return resourceDeviceAuthorizationRead(ctx, d, m)
 }
 
 func resourceDeviceAuthorizationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -46,7 +46,7 @@ func resourceDeviceKeyCreate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	d.SetId(deviceID)
-	return nil
+	return resourceDeviceKeyRead(ctx, d, m)
 }
 
 func resourceDeviceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -106,5 +106,5 @@ func resourceDeviceKeyUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		return diagnosticsError(err, "failed to update device key")
 	}
 
-	return nil
+	return resourceDeviceKeyRead(ctx, d, m)
 }

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -65,7 +65,7 @@ func resourceDeviceSubnetRoutesCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	d.SetId(createUUID())
-	return nil
+	return resourceDeviceSubnetRoutesRead(ctx, d, m)
 }
 
 func resourceDeviceSubnetRoutesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -82,7 +82,7 @@ func resourceDeviceSubnetRoutesUpdate(ctx context.Context, d *schema.ResourceDat
 		return diagnosticsError(err, "Failed to set device subnet routes")
 	}
 
-	return nil
+	return resourceDeviceSubnetRoutesRead(ctx, d, m)
 }
 
 func resourceDeviceSubnetRoutesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -77,7 +77,7 @@ func resourceDeviceTagsCreate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	d.SetId(deviceID)
-	return nil
+	return resourceDeviceTagsRead(ctx, d, m)
 }
 
 func resourceDeviceTagsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -95,7 +95,7 @@ func resourceDeviceTagsUpdate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	d.SetId(deviceID)
-	return nil
+	return resourceDeviceTagsRead(ctx, d, m)
 }
 
 func resourceDeviceTagsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -58,7 +58,7 @@ func resourceDNSNameserversCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(createUUID())
-	return nil
+	return resourceDNSNameserversRead(ctx, d, m)
 }
 
 func resourceDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -78,7 +78,7 @@ func resourceDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diagnosticsError(err, "Failed to set dns nameservers")
 	}
 
-	return nil
+	return resourceDNSNameserversRead(ctx, d, m)
 }
 
 func resourceDNSNameserversDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -56,7 +56,7 @@ func resourceDNSPreferencesCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(createUUID())
-	return nil
+	return resourceDNSPreferencesRead(ctx, d, m)
 }
 
 func resourceDNSPreferencesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -75,7 +75,7 @@ func resourceDNSPreferencesUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diagnosticsError(err, "Failed to set dns preferences")
 	}
 
-	return nil
+	return resourceDNSPreferencesRead(ctx, d, m)
 }
 
 func resourceDNSPreferencesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -57,7 +57,7 @@ func resourceDNSSearchPathsCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(createUUID())
-	return nil
+	return resourceDNSSearchPathsRead(ctx, d, m)
 }
 
 func resourceDNSSearchPathsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -77,7 +77,7 @@ func resourceDNSSearchPathsUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diagnosticsError(err, "Failed to fetch set search paths")
 	}
 
-	return nil
+	return resourceDNSSearchPathsRead(ctx, d, m)
 }
 
 func resourceDNSSearchPathsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -73,7 +73,7 @@ func resourceSplitDNSNameserversCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	d.SetId(domain)
-	return nil
+	return resourceSplitDNSNameserversRead(ctx, d, m)
 }
 
 func resourceSplitDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -153,7 +153,7 @@ func resourceTailnetKeyCreate(ctx context.Context, d *schema.ResourceData, m int
 		return diagnosticsError(err, "Failed to set 'invalid'")
 	}
 
-	return nil
+	return resourceTailnetKeyRead(ctx, d, m)
 }
 
 func resourceTailnetKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -67,6 +67,9 @@ func testTailnetKeyStruct(reusable bool) tailscale.Key {
 
 func setKeyStep(reusable bool, recreateIfInvalid string) resource.TestStep {
 	return resource.TestStep{
+		PreConfig: func() {
+			testServer.ResponseBody = testTailnetKeyStruct(reusable)
+		},
 		ResourceName: "tailscale_tailnet_key.example_key",
 		Config: fmt.Sprintf(`
 			resource "tailscale_tailnet_key" "example_key" {


### PR DESCRIPTION
Add calls to appropriate `Read` functions at the end of `Create` and `Update` functions to follow recommended best practices from HashiCorp. This is done to prevent scenarios where Terraform could otherwise have stale state after resource creation or update (from default or computed values being populated server side on the object as an example) which can result in unexpected drift in subsequent plan / apply operations.

Fixes https://github.com/tailscale/corp/issues/19698