### PR TITLE
fix imports for splitdns

### DIFF
--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -44,6 +44,12 @@ func resourceSplitDNSNameserversRead(ctx context.Context, d *schema.ResourceData
 		return diagnosticsError(err, "Failed to fetch split DNS configs")
 	}
 
+	domain := d.Id()
+
+	if err = d.Set("domain", domain); err != nil {
+		return diag.FromErr(err)
+	}
+
 	nameservers := splitDNS[d.Id()]
 
 	if err = d.Set("nameservers", nameservers); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if you use import on `tailscale_dns_split_nameservers`, the `domain` attribute will get set to `null` in the terraform state, and thus will result in 

Since the resource ID and domain are the same, set domain to the resource ID.
sample code:

```
import {
  to = tailscale_dns_split_nameservers.example-com
  id = "example.com"
}

resource "tailscale_dns_split_nameservers" "example-com" {
  domain      = "example.com"
  nameservers = [
        "1.2.3.4",
        "5.6.7.8"
  ]
}
```
Before:
```
# tailscale_dns_split_nameservers.example-com will be updated in-place
~ resource "tailscale_dns_split_nameservers" "example-com" {
    + domain      = "example.com"
      id          = "example.com"
      nameservers = [
        "1.2.3.4",
        "5.6.7.8"
      ]
  }
```

after:
```
  # tailscale_dns_split_nameservers.example-com will be imported
resource "tailscale_dns_split_nameservers" "example-com" {
    domain      = "example.com"
    id          = "example.com"
    nameservers = [
        "1.2.3.4",
        "5.6.7.8"
      ]
}
```

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

see above

**Special notes for your reviewer**:
