### PR TITLE
tailscale: update state after modification for ACL resource

### DIFF
--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -132,7 +132,7 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 
 	d.SetId(createUUID())
-	return nil
+	return resourceACLRead(ctx, d, m)
 }
 
 func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -146,5 +146,5 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diagnosticsError(err, "Failed to set ACL")
 	}
 
-	return nil
+	return resourceACLRead(ctx, d, m)
 }


### PR DESCRIPTION
Adds calls to `Read` after doing `Create` or `Update` operations for the ACL resource. This resource was missed in #362 where it was added for other existing resources.

Fixes https://github.com/tailscale/corp/issues/19698
