### PR TITLE
.github/workflows: use --clean instead of deprecated --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
As per https://goreleaser.com/deprecations/#__tabbed_17_1 `--rm-dist` has been deprecated in favour of `--clean`.

Updates #cleanup