### PR TITLE
tailscale: add initial acceptance testing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,15 @@ provider_installation {
   direct {}
 }
 ```
+
+#### Acceptance Tests
+
+Tests in this repo that are prefixed with `TestAcc` are acceptance tests which run against a real instance of the tailscale control plane.
+These tests are skipped unless the `TF_ACC` environment variable is set.
+Running `make testacc` sets the `TF_ACC` variable and runs the tests.
+
+The `TF_ACC` environment variable is handled by [Terraform core code](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests#requirements-and-recommendations)
+and is not directly referenced in provider code.
+
+The `TAILSCALE_BASE_URL` and `TAILSCALE_API_KEY` environment variables must also be set for these tests.
+Tests will be performed against the tailnet which `TAILSCALE_API_KEY` belongs to.

--- a/tailscale/resource_webhook_test.go
+++ b/tailscale/resource_webhook_test.go
@@ -1,10 +1,15 @@
 package tailscale_test
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/tailscale/tailscale-client-go/tailscale"
 )
@@ -14,6 +19,13 @@ const testWebhook = `
 		endpoint_url = "https://example.com/endpoint"
 		provider_type = "slack"
 		subscriptions = ["userNeedsApproval", "nodeCreated"]
+	}`
+
+const testWebhookUpdate = `
+	resource "tailscale_webhook" "test_webhook" {
+		endpoint_url = "https://example.com/endpoint"
+		provider_type = "slack"
+		subscriptions = ["nodeCreated", "userSuspended", "userRoleUpdated"]
 	}`
 
 func TestProvider_TailscaleWebhook(t *testing.T) {
@@ -31,4 +43,168 @@ func TestProvider_TailscaleWebhook(t *testing.T) {
 			testResourceDestroyed("tailscale_webhook.test_webhook", testWebhook),
 		},
 	})
+}
+
+func TestAccTailscaleWebhook_Basic(t *testing.T) {
+	webhook := &tailscale.Webhook{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:      testAccCheckWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testWebhook,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebhookExists("tailscale_webhook.test_webhook", webhook),
+					testAccCheckWebhookProperties(webhook),
+					resource.TestCheckResourceAttr("tailscale_webhook.test_webhook", "endpoint_url", "https://example.com/endpoint"),
+					resource.TestCheckResourceAttr("tailscale_webhook.test_webhook", "provider_type", "slack"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "userNeedsApproval"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "nodeCreated"),
+					resource.TestCheckResourceAttrSet("tailscale_webhook.test_webhook", "secret"),
+				),
+			},
+			{
+				ResourceName:            "tailscale_webhook.test_webhook",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret"},
+			},
+		},
+	})
+}
+
+func TestAccTailscaleWebhook_Update(t *testing.T) {
+	webhook := &tailscale.Webhook{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:      testAccCheckWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testWebhook,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebhookExists("tailscale_webhook.test_webhook", webhook),
+					testAccCheckWebhookProperties(webhook),
+					resource.TestCheckResourceAttr("tailscale_webhook.test_webhook", "endpoint_url", "https://example.com/endpoint"),
+					resource.TestCheckResourceAttr("tailscale_webhook.test_webhook", "provider_type", "slack"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "userNeedsApproval"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "nodeCreated"),
+					resource.TestCheckResourceAttrSet("tailscale_webhook.test_webhook", "secret"),
+				),
+			},
+			{
+				Config: testWebhookUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebhookExists("tailscale_webhook.test_webhook", webhook),
+					testAccCheckWebhookPropertiesUpdated(webhook),
+					resource.TestCheckResourceAttr("tailscale_webhook.test_webhook", "endpoint_url", "https://example.com/endpoint"),
+					resource.TestCheckResourceAttr("tailscale_webhook.test_webhook", "provider_type", "slack"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "nodeCreated"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "userSuspended"),
+					resource.TestCheckTypeSetElemAttr("tailscale_webhook.test_webhook", "subscriptions.*", "userRoleUpdated"),
+					resource.TestCheckResourceAttrSet("tailscale_webhook.test_webhook", "secret"),
+				),
+			},
+			{
+				ResourceName:            "tailscale_webhook.test_webhook",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret"},
+			},
+		},
+	})
+}
+
+func testAccCheckWebhookExists(resourceName string, webhook *tailscale.Webhook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource has no ID set")
+		}
+
+		client := testAccProvider.Meta().(*tailscale.Client)
+		out, err := client.Webhook(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*webhook = *out
+		return nil
+	}
+}
+
+func testAccCheckWebhookDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*tailscale.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tailscale_webhook" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource has no ID set")
+		}
+
+		_, err := client.Webhook(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("webhook %s still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckWebhookProperties(webhook *tailscale.Webhook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if webhook.EndpointURL != "https://example.com/endpoint" {
+			return fmt.Errorf("bad webhook.endpoint_url: %s", webhook.EndpointURL)
+		}
+		if webhook.ProviderType != "slack" {
+			return fmt.Errorf("bad webhook.provider_type: %s", webhook.ProviderType)
+		}
+
+		expectedSubscriptions := []tailscale.WebhookSubscriptionType{
+			tailscale.WebhookNodeCreated,
+			tailscale.WebhookUserNeedsApproval,
+		}
+
+		slices.Sort(expectedSubscriptions)
+		slices.Sort(webhook.Subscriptions)
+
+		if !reflect.DeepEqual(webhook.Subscriptions, expectedSubscriptions) {
+			return fmt.Errorf("bad webhook.subscriptions: %#v", webhook.Subscriptions)
+		}
+		return nil
+	}
+}
+
+func testAccCheckWebhookPropertiesUpdated(webhook *tailscale.Webhook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if webhook.EndpointURL != "https://example.com/endpoint" {
+			return fmt.Errorf("bad webhook.endpoint_url: %s", webhook.EndpointURL)
+		}
+		if webhook.ProviderType != "slack" {
+			return fmt.Errorf("bad webhook.provider_type: %s", webhook.ProviderType)
+		}
+
+		expectedSubscriptions := []tailscale.WebhookSubscriptionType{
+			tailscale.WebhookNodeCreated,
+			tailscale.WebhookUserRoleUpdated,
+			tailscale.WebhookUserSuspended,
+		}
+
+		slices.Sort(expectedSubscriptions)
+		slices.Sort(webhook.Subscriptions)
+
+		if !reflect.DeepEqual(webhook.Subscriptions, expectedSubscriptions) {
+			return fmt.Errorf("bad webhook.subscriptions: %#v", webhook.Subscriptions)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
Add initial acceptance testing setup logic and a basic acceptance test for the new webhook resource.

Updates https://github.com/tailscale/corp/issues/21842