### PR TITLE
tailscale: add support for using v2 tailscale-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19
+	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240801195603-6096900af9df
 	golang.org/x/tools v0.23.0
 	tailscale.com v1.70.0
 )

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29X
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19 h1:fRLv1yZH1ueL1cnpLhOnOymoBfMCIviCn0e0VkAjkK4=
 github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19/go.mod h1:jbwJyHniK3nyLttwcDTXnfdDQEnADvc4VMOP8hZWnR0=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240801195603-6096900af9df h1:XjHI0pFxhttM1nEn/WNGOO3wrJYEJSZarJm0i5WFXgY=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240801195603-6096900af9df/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/tailscale/data_source_acl.go
+++ b/tailscale/data_source_acl.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/tailscale/hujson"
-	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func dataSourceACL() *schema.Resource {
@@ -30,7 +29,7 @@ func dataSourceACL() *schema.Resource {
 }
 
 func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	acl, err := client.RawACL(ctx)
 	if err != nil {

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -71,7 +71,7 @@ func dataSourceDevice() *schema.Resource {
 }
 
 func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	var filter func(d tailscale.Device) bool
 	var filterDesc string

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func dataSourceDevices() *schema.Resource {
@@ -70,7 +68,7 @@ func dataSourceDevices() *schema.Resource {
 }
 
 func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	devices, err := client.Devices(ctx)
 	if err != nil {

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -12,11 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	ts "github.com/tailscale/tailscale-client-go/tailscale"
 	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
-var testClient *ts.Client
+var testClients *tailscale.Clients
 var testServer *TestServer
 var testAccProvider = tailscale.Provider()
 
@@ -70,13 +69,13 @@ func TestProvider_Implemented(t *testing.T) {
 func testProviderFactories(t *testing.T) map[string]func() (*schema.Provider, error) {
 	t.Helper()
 
-	testClient, testServer = NewTestHarness(t)
+	testClients, testServer = NewTestHarness(t)
 	return map[string]func() (*schema.Provider, error){
 		"tailscale": func() (*schema.Provider, error) {
 			return tailscale.Provider(func(p *schema.Provider) {
 				// Set up a test harness for the provider
 				p.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
-					return testClient, nil
+					return testClients, nil
 				}
 
 				// Don't require any of the global configuration

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -35,7 +35,7 @@ func resourceACL() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: func(ctx context.Context, rd *schema.ResourceDiff, m interface{}) error {
-			client := m.(*tailscale.Client)
+			client := m.(*Clients).V1
 
 			//if the acl is only known after apply, then acl will be an empty string and validation will fail
 			if rd.Get("acl").(string) == "" {
@@ -97,7 +97,7 @@ func resourceACL() *schema.Resource {
 }
 
 func resourceACLRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	acl, err := client.RawACL(ctx)
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch ACL")
@@ -110,7 +110,7 @@ func resourceACLRead(ctx context.Context, d *schema.ResourceData, m interface{})
 }
 
 func resourceACLCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	acl := d.Get("acl").(string)
 
 	// Setting the `ts-default` ETag will make this operation succeed only if
@@ -136,7 +136,7 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	if !d.HasChange("acl") {
 		return nil

--- a/tailscale/resource_contacts.go
+++ b/tailscale/resource_contacts.go
@@ -75,7 +75,7 @@ func resourceContacts() *schema.Resource {
 }
 
 func resourceContactsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	if diagErr := updateContact(ctx, client, d, tailscale.ContactAccount); diagErr != nil {
 		return diagErr
@@ -94,7 +94,7 @@ func resourceContactsCreate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceContactsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	contacts, err := client.Contacts(ctx)
 	if err != nil {
@@ -117,7 +117,7 @@ func resourceContactsRead(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceContactsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	if d.HasChange("account") {
 		if diagErr := updateContact(ctx, client, d, tailscale.ContactAccount); diagErr != nil {

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -35,7 +35,7 @@ func resourceDeviceAuthorization() *schema.Resource {
 }
 
 func resourceDeviceAuthorizationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Id()
 
 	devices, err := client.Devices(ctx)
@@ -64,7 +64,7 @@ func resourceDeviceAuthorizationRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceDeviceAuthorizationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 	authorized := d.Get("authorized").(bool)
 
@@ -79,7 +79,7 @@ func resourceDeviceAuthorizationCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceDeviceAuthorizationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 
 	devices, err := client.Devices(ctx)

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -32,7 +32,7 @@ func resourceDeviceKey() *schema.Resource {
 }
 
 func resourceDeviceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	deviceID := d.Get("device_id").(string)
 	keyExpiryDisabled := d.Get("key_expiry_disabled").(bool)
@@ -50,7 +50,7 @@ func resourceDeviceKeyCreate(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func resourceDeviceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	deviceID := d.Get("device_id").(string)
 	key := tailscale.DeviceKey{}
@@ -63,7 +63,7 @@ func resourceDeviceKeyDelete(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func resourceDeviceKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 
 	devices, err := client.Devices(ctx)
@@ -93,7 +93,7 @@ func resourceDeviceKeyRead(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceDeviceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	deviceID := d.Get("device_id").(string)
 	keyExpiryDisabled := d.Get("key_expiry_disabled").(bool)

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDeviceSubnetRoutes() *schema.Resource {
@@ -35,7 +33,7 @@ func resourceDeviceSubnetRoutes() *schema.Resource {
 }
 
 func resourceDeviceSubnetRoutesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 
 	routes, err := client.DeviceSubnetRoutes(ctx, deviceID)
@@ -51,7 +49,7 @@ func resourceDeviceSubnetRoutesRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceDeviceSubnetRoutesCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 	routes := d.Get("routes").(*schema.Set).List()
 
@@ -69,7 +67,7 @@ func resourceDeviceSubnetRoutesCreate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceDeviceSubnetRoutesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 	routes := d.Get("routes").(*schema.Set).List()
 
@@ -86,7 +84,7 @@ func resourceDeviceSubnetRoutesUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceDeviceSubnetRoutesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 
 	if err := client.SetDeviceSubnetRoutes(ctx, deviceID, []string{}); err != nil {

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -35,7 +35,7 @@ func resourceDeviceTags() *schema.Resource {
 }
 
 func resourceDeviceTagsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 
 	devices, err := client.Devices(ctx)
@@ -63,7 +63,7 @@ func resourceDeviceTagsRead(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceDeviceTagsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 	set := d.Get("tags").(*schema.Set)
 
@@ -81,7 +81,7 @@ func resourceDeviceTagsCreate(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func resourceDeviceTagsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 	set := d.Get("tags").(*schema.Set)
 
@@ -99,7 +99,7 @@ func resourceDeviceTagsUpdate(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func resourceDeviceTagsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	deviceID := d.Get("device_id").(string)
 
 	if err := client.SetDeviceTags(ctx, deviceID, []string{}); err != nil {

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDNSNameservers() *schema.Resource {
@@ -31,7 +29,7 @@ func resourceDNSNameservers() *schema.Resource {
 }
 
 func resourceDNSNameserversRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	servers, err := client.DNSNameservers(ctx)
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch dns nameservers")
@@ -45,7 +43,7 @@ func resourceDNSNameserversRead(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func resourceDNSNameserversCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	nameservers := d.Get("nameservers").([]interface{})
 
 	servers := make([]string, len(nameservers))
@@ -66,7 +64,7 @@ func resourceDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m
 		return resourceDNSNameserversRead(ctx, d, m)
 	}
 
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	nameservers := d.Get("nameservers").([]interface{})
 
 	servers := make([]string, len(nameservers))
@@ -82,7 +80,7 @@ func resourceDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceDNSNameserversDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	if err := client.SetDNSNameservers(ctx, []string{}); err != nil {
 		return diagnosticsError(err, "Failed to set dns nameservers")

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -30,7 +30,7 @@ func resourceDNSPreferences() *schema.Resource {
 }
 
 func resourceDNSPreferencesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	preferences, err := client.DNSPreferences(ctx)
 	if err != nil {
@@ -45,7 +45,7 @@ func resourceDNSPreferencesRead(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func resourceDNSPreferencesCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	magicDNS := d.Get("magic_dns").(bool)
 	preferences := tailscale.DNSPreferences{
 		MagicDNS: magicDNS,
@@ -64,7 +64,7 @@ func resourceDNSPreferencesUpdate(ctx context.Context, d *schema.ResourceData, m
 		return resourceDNSPreferencesRead(ctx, d, m)
 	}
 
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	magicDNS := d.Get("magic_dns").(bool)
 
 	preferences := tailscale.DNSPreferences{
@@ -79,7 +79,7 @@ func resourceDNSPreferencesUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceDNSPreferencesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	if err := client.SetDNSPreferences(ctx, tailscale.DNSPreferences{}); err != nil {
 		return diagnosticsError(err, "Failed to set dns preferences")

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 func resourceDNSSearchPaths() *schema.Resource {
@@ -30,7 +28,7 @@ func resourceDNSSearchPaths() *schema.Resource {
 }
 
 func resourceDNSSearchPathsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	paths, err := client.DNSSearchPaths(ctx)
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch dns search paths")
@@ -44,7 +42,7 @@ func resourceDNSSearchPathsRead(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func resourceDNSSearchPathsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	paths := d.Get("search_paths").([]interface{})
 
 	searchPaths := make([]string, len(paths))
@@ -65,7 +63,7 @@ func resourceDNSSearchPathsUpdate(ctx context.Context, d *schema.ResourceData, m
 		return resourceDNSSearchPathsRead(ctx, d, m)
 	}
 
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	paths := d.Get("search_paths").([]interface{})
 
 	searchPaths := make([]string, len(paths))
@@ -81,7 +79,7 @@ func resourceDNSSearchPathsUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceDNSSearchPathsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	if err := client.SetDNSSearchPaths(ctx, []string{}); err != nil {
 		return diagnosticsError(err, "Failed to fetch set search paths")

--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -38,7 +38,7 @@ func resourceDNSSplitNameservers() *schema.Resource {
 }
 
 func resourceSplitDNSNameserversRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	splitDNS, err := client.SplitDNS(ctx)
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch split DNS configs")
@@ -60,7 +60,7 @@ func resourceSplitDNSNameserversRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceSplitDNSNameserversCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	nameserversSet := d.Get("nameservers").(*schema.Set)
 	domain := d.Get("domain").(string)
 
@@ -91,7 +91,7 @@ func resourceSplitDNSNameserversUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceSplitDNSNameserversDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	domain := d.Get("domain").(string)
 
 	req := make(tailscale.SplitDnsRequest)

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -104,7 +104,7 @@ func resourceTailnetKey() *schema.Resource {
 }
 
 func resourceTailnetKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	reusable := d.Get("reusable").(bool)
 	ephemeral := d.Get("ephemeral").(bool)
 	preauthorized := d.Get("preauthorized").(bool)
@@ -157,7 +157,7 @@ func resourceTailnetKeyCreate(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func resourceTailnetKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	err := client.DeleteKey(ctx, d.Id())
 	switch {
@@ -199,7 +199,7 @@ func resourceTailnetKeyDiff(ctx context.Context, d *schema.ResourceDiff, m inter
 		return nil
 	}
 
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	key, err := client.GetKey(ctx, d.Id())
 	if tailscale.IsNotFound(err) || (err == nil && key.Invalid) {
 		d.ForceNew("recreate_if_invalid")
@@ -210,7 +210,7 @@ func resourceTailnetKeyDiff(ctx context.Context, d *schema.ResourceDiff, m inter
 func resourceTailnetKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	recreateIfInvalid := shouldRecreateIfInvalid(d.Get("reusable").(bool), d.Get("recreate_if_invalid").(string))
 
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	key, err := client.GetKey(ctx, d.Id())
 
 	switch {

--- a/tailscale/resource_webhook.go
+++ b/tailscale/resource_webhook.go
@@ -83,7 +83,7 @@ func resourceWebhook() *schema.Resource {
 }
 
 func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	endpointURL := d.Get("endpoint_url").(string)
 	providerType := tailscale.WebhookProviderType(d.Get("provider_type").(string))
@@ -113,7 +113,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	webhook, err := client.Webhook(ctx, d.Id())
 	if err != nil {
@@ -144,7 +144,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		return resourceWebhookRead(ctx, d, m)
 	}
 
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 	subscriptions := d.Get("subscriptions").(*schema.Set).List()
 
 	var requestSubscriptions []tailscale.WebhookSubscriptionType
@@ -161,7 +161,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceWebhookDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+	client := m.(*Clients).V1
 
 	err := client.DeleteWebhook(ctx, d.Id())
 	if err != nil {


### PR DESCRIPTION
Updates tailscale/corp#21867

We want to switch to using the new v2 of the tailscale-go-client. This initializes the appropriate clients so that we can start using them.