### PR TITLE
tailscale: add acceptance test for device_authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,10 @@ Running `make testacc` sets the `TF_ACC` variable and runs the tests.
 The `TF_ACC` environment variable is handled by [Terraform core code](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests#requirements-and-recommendations)
 and is not directly referenced in provider code.
 
-The `TAILSCALE_BASE_URL` and `TAILSCALE_API_KEY` environment variables must also be set for these tests.
-Tests will be performed against the tailnet which `TAILSCALE_API_KEY` belongs to.
+The following tailscale specific environment variables must also be set:
+- `TAILSCALE_BASE_URL`
+  - URL of the control plane
+- `TAILSCALE_API_KEY`
+  - Tests will be performed against the tailnet which the key belongs to
+- `TAILSCALE_TEST_DEVICE_NAME`
+  - The FQDN of a device owned by the owner of the API key in use

--- a/docs/resources/device_authorization.md
+++ b/docs/resources/device_authorization.md
@@ -34,3 +34,12 @@ resource "tailscale_device_authorization" "sample_authorization" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Device authorization can be imported using the device id, e.g.,
+terraform import tailscale_device_authorization.sample_authorization 123456789
+```

--- a/examples/resources/tailscale_device_authorization/import.sh
+++ b/examples/resources/tailscale_device_authorization/import.sh
@@ -1,0 +1,2 @@
+# Device authorization can be imported using the device id, e.g.,
+terraform import tailscale_device_authorization.sample_authorization 123456789

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -34,6 +34,10 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("TAILSCALE_BASE_URL must be set for acceptance tests")
 	}
 
+	if v := os.Getenv("TAILSCALE_TEST_DEVICE_NAME"); v == "" {
+		t.Fatal("TAILSCALE_TEST_DEVICE_NAME must be set for acceptance tests")
+	}
+
 	if diags := testAccProvider.Configure(context.Background(), &terraform.ResourceConfig{}); diags.HasError() {
 		for _, d := range diags {
 			if d.Severity == diag.Error {

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -16,6 +16,9 @@ func resourceDeviceAuthorization() *schema.Resource {
 		CreateContext: resourceDeviceAuthorizationCreate,
 		UpdateContext: resourceDeviceAuthorizationUpdate,
 		DeleteContext: resourceDeviceAuthorizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"device_id": {
 				Type:        schema.TypeString,
@@ -33,7 +36,7 @@ func resourceDeviceAuthorization() *schema.Resource {
 
 func resourceDeviceAuthorizationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*tailscale.Client)
-	deviceID := d.Get("device_id").(string)
+	deviceID := d.Id()
 
 	devices, err := client.Devices(ctx)
 	if err != nil {
@@ -55,6 +58,7 @@ func resourceDeviceAuthorizationRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	d.SetId(selected.ID)
+	d.Set("device_id", selected.ID)
 	d.Set("authorized", selected.Authorized)
 	return nil
 }

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -1,17 +1,20 @@
 package tailscale_test
 
 import (
-	"net/http"
+	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
 const testDeviceAuthorization = `
 	data "tailscale_device" "test_device" {
-		name = "device.example.com"
+		name = "%s"
 	}
 	
 	resource "tailscale_device_authorization" "test_authorization" {
@@ -19,24 +22,106 @@ const testDeviceAuthorization = `
 		authorized = true
 	}`
 
-func TestProvider_TailscaleDeviceAuthorization(t *testing.T) {
+func TestAccTailscaleDeviceAuthorization_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		PreCheck: func() {
-			testServer.ResponseCode = http.StatusOK
-			testServer.ResponseBody = map[string][]tailscale.Device{
-				"devices": {
-					{
-						Name: "device.example.com",
-						ID:   "123",
-					},
-				},
-			}
-		},
-		ProviderFactories: testProviderFactories(t),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:      testAccCheckDeviceAuthorizationDestroy,
 		Steps: []resource.TestStep{
-			testResourceCreated("tailscale_device_authorization.test_authorization", testDeviceAuthorization),
-			testResourceDestroyed("tailscale_device_authorization.test_authorization", testDeviceAuthorization),
+			{
+				Config: generateBasicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceAuthorized("tailscale_device_authorization.test_authorization"),
+					resource.TestCheckResourceAttr("tailscale_device_authorization.test_authorization", "authorized", "true"),
+				),
+			},
+			{
+				ResourceName:      "tailscale_device_authorization.test_authorization",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
+}
+
+func generateBasicConfig() string {
+	return fmt.Sprintf(testDeviceAuthorization, os.Getenv("TAILSCALE_TEST_DEVICE_NAME"))
+}
+
+func testAccCheckDeviceAuthorized(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource has no ID set")
+		}
+
+		client := testAccProvider.Meta().(*tailscale.Client)
+		// Devices are not currently deauthorized when this resource is deleted,
+		// expect that the device both exists and is still authorized.
+		devices, err := client.Devices(context.Background())
+		if err != nil {
+			return err
+		}
+
+		var selected *tailscale.Device
+		for _, device := range devices {
+			if device.ID == rs.Primary.ID {
+				selected = &device
+				break
+			}
+		}
+
+		if selected == nil {
+			return fmt.Errorf("expected device with id %q to exist", rs.Primary.ID)
+		}
+
+		if selected.Authorized != true {
+			return fmt.Errorf("device with id %q is not authorized", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDeviceAuthorizationDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*tailscale.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tailscale_device_authorization" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource has no ID set")
+		}
+
+		// Devices are not currently deauthorized when this resource is deleted,
+		// expect that the device both exists and is still authorized.
+		devices, err := client.Devices(context.Background())
+		if err != nil {
+			return err
+		}
+
+		var selected *tailscale.Device
+		for _, device := range devices {
+			if device.ID == rs.Primary.ID {
+				selected = &device
+				break
+			}
+		}
+
+		if selected == nil {
+			return fmt.Errorf("expected device with id %q to exist", rs.Primary.ID)
+		}
+
+		if selected.Authorized != true {
+			return fmt.Errorf("device with id %q is not authorized", rs.Primary.ID)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add basic acceptance test for device_authorization. Also add logic to allow for importing `device_authorization` while I was here.

Updates https://github.com/tailscale/corp/issues/21842