### PR TITLE
.gitignore: ignore provider binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+terraform-provider-tailscale


### PR DESCRIPTION
Add `terraform-provider-tailscale` to .gitignore.

Updates #cleanup
