### PR TITLE
tailscale: use v2 client for dns nameservers

### DIFF
--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -29,8 +29,8 @@ func resourceDNSNameservers() *schema.Resource {
 }
 
 func resourceDNSNameserversRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Clients).V1
-	servers, err := client.DNSNameservers(ctx)
+	client := m.(*Clients).V2
+	servers, err := client.DNS().Nameservers(ctx)
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch dns nameservers")
 	}
@@ -43,7 +43,7 @@ func resourceDNSNameserversRead(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func resourceDNSNameserversCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Clients).V1
+	client := m.(*Clients).V2
 	nameservers := d.Get("nameservers").([]interface{})
 
 	servers := make([]string, len(nameservers))
@@ -51,8 +51,8 @@ func resourceDNSNameserversCreate(ctx context.Context, d *schema.ResourceData, m
 		servers[i] = server.(string)
 	}
 
-	if err := client.SetDNSNameservers(ctx, servers); err != nil {
-		return diagnosticsError(err, "Failed to set dns nameservers")
+	if err := client.DNS().SetNameservers(ctx, servers); err != nil {
+		return diagnosticsError(err, "Failed to create dns nameservers")
 	}
 
 	d.SetId(createUUID())
@@ -64,7 +64,7 @@ func resourceDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m
 		return resourceDNSNameserversRead(ctx, d, m)
 	}
 
-	client := m.(*Clients).V1
+	client := m.(*Clients).V2
 	nameservers := d.Get("nameservers").([]interface{})
 
 	servers := make([]string, len(nameservers))
@@ -72,17 +72,17 @@ func resourceDNSNameserversUpdate(ctx context.Context, d *schema.ResourceData, m
 		servers[i] = server.(string)
 	}
 
-	if err := client.SetDNSNameservers(ctx, servers); err != nil {
-		return diagnosticsError(err, "Failed to set dns nameservers")
+	if err := client.DNS().SetNameservers(ctx, servers); err != nil {
+		return diagnosticsError(err, "Failed to update dns nameservers")
 	}
 
 	return resourceDNSNameserversRead(ctx, d, m)
 }
 
 func resourceDNSNameserversDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Clients).V1
+	client := m.(*Clients).V2
 
-	if err := client.SetDNSNameservers(ctx, []string{}); err != nil {
+	if err := client.DNS().SetNameservers(ctx, []string{}); err != nil {
 		return diagnosticsError(err, "Failed to set dns nameservers")
 	}
 

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -1,17 +1,30 @@
 package tailscale_test
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
 )
 
-const testNameservers = `
+const testNameserversCreate = `
 	resource "tailscale_dns_nameservers" "test_nameservers" {
 		nameservers = [
 			"8.8.8.8",
 			"8.8.4.4",
+		]
+	}`
+
+const testNameserversUpdate = `
+	resource "tailscale_dns_nameservers" "test_nameservers" {
+		nameservers = [
+			"1.1.1.1",
 		]
 	}`
 
@@ -24,8 +37,54 @@ func TestProvider_TailscaleDNSNameservers(t *testing.T) {
 		},
 		ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
-			testResourceCreated("tailscale_dns_nameservers.test_nameservers", testNameservers),
-			testResourceDestroyed("tailscale_dns_nameservers.test_nameservers", testNameservers),
+			testResourceCreated("tailscale_dns_nameservers.test_nameservers", testNameserversCreate),
+			testResourceDestroyed("tailscale_dns_nameservers.test_nameservers", testNameserversCreate),
+		},
+	})
+}
+
+func TestAccTailscaleDNSNameservers(t *testing.T) {
+	const resourceName = "tailscale_dns_nameservers.test_nameservers"
+
+	checkProperties := func(expected []string) func(client *tsclient.Client, rs *terraform.ResourceState) error {
+		return func(client *tsclient.Client, rs *terraform.ResourceState) error {
+			actual, err := client.DNS().Nameservers(context.Background())
+			if err != nil {
+				return err
+			}
+
+			if diff := cmp.Diff(actual, expected); diff != "" {
+				return fmt.Errorf("wrong nameservers: (-got+want) \n%s", diff)
+			}
+
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties([]string{})),
+		Steps: []resource.TestStep{
+			{
+				Config: testNameserversCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties([]string{"8.8.8.8", "8.8.4.4"}),
+					),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.8.8"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.4.4"),
+				),
+			},
+			{
+				Config: testNameserversUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties([]string{"1.1.1.1"}),
+					),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "1.1.1.1"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
 Updates tailscale/corp#21867