### PR TITLE
tailscale: use new DevicePosture().Get() API to read specific posture…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tailscale/terraform-provider-tailscale
 go 1.22.0
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
@@ -10,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19
-	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240812214327-56a86b97d431
+	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240819223802-3a9fb56052db
 	golang.org/x/tools v0.24.0
 	tailscale.com v1.70.0
 )
@@ -31,7 +32,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,10 +190,8 @@ github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29X
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19 h1:fRLv1yZH1ueL1cnpLhOnOymoBfMCIviCn0e0VkAjkK4=
 github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19/go.mod h1:jbwJyHniK3nyLttwcDTXnfdDQEnADvc4VMOP8hZWnR0=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240809180132-6e74358b7c05 h1:A8B7UqZborDh95uVsESpfQGkKbsii9lad7/Uyd2SR60=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240809180132-6e74358b7c05/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240812214327-56a86b97d431 h1:+O4tjBU67i+EXvfxRo0oq6DGCU9rzA4qqRpyYfEJDcY=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240812214327-56a86b97d431/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240819223802-3a9fb56052db h1:sckiiaymnxDtxozA8jGc2cAU1X/0vEmKULvAP8fTS1o=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240819223802-3a9fb56052db/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -62,18 +62,11 @@ func resourcePostureIntegration() *schema.Resource {
 func resourcePostureIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Clients).V2
 
-	integrations, err := client.DevicePosture().ListIntegrations(ctx)
+	integration, err := client.DevicePosture().GetIntegration(ctx, d.Id())
 	if err != nil {
-		return diagnosticsError(err, "Failed to fetch posture integrations")
+		return diagnosticsError(err, "Failed to find posture integration with id %q", d.Id())
 	}
-
-	for _, integration := range integrations {
-		if integration.ID == d.Id() {
-			return resourcePostureIntegrationUpdateFromRemote(d, &integration)
-		}
-	}
-
-	return diagnosticsError(err, "Failed to find posture integration with id %q", d.Id())
+	return resourcePostureIntegrationUpdateFromRemote(d, integration)
 }
 
 func resourcePostureIntegrationUpdateFromRemote(d *schema.ResourceData, integration *tsclient.PostureIntegration) diag.Diagnostics {


### PR DESCRIPTION
… integrations

This is more efficient, and simpler, than listing all posture integrations and extracting the one with a matching id.

Updates tailscale/corp#21624

Depends on:

- https://github.com/tailscale/corp/pull/22435
- https://github.com/tailscale/tailscale-client-go/pull/102