### PR TITLE
tailscale: don't use t.Fatal in acceptance tests

### DIFF
--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -187,7 +187,7 @@ func TestAccACL(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("diff found (-got, +want): %s", diff)
+				return fmt.Errorf("diff found (-got, +want): %s", diff)
 			}
 
 			return nil

--- a/tailscale/resource_dns_preferences_test.go
+++ b/tailscale/resource_dns_preferences_test.go
@@ -2,6 +2,7 @@ package tailscale_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -48,7 +49,7 @@ func TestAccTailscaleDNSPreferences(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("diff found (-got, +want): %s", diff)
+				return fmt.Errorf("diff found (-got, +want): %s", diff)
 			}
 
 			return nil

--- a/tailscale/resource_tailnet_settings_test.go
+++ b/tailscale/resource_tailnet_settings_test.go
@@ -2,6 +2,7 @@ package tailscale_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,7 +43,7 @@ func TestAccTailscaleTailnetSettings(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("diff found (-got, +want): %s", diff)
+				return fmt.Errorf("diff found (-got, +want): %s", diff)
 			}
 
 			return nil


### PR DESCRIPTION
Instead, return errors to allow acceptance test scaffolding to report failures as conventional.

Updates tailscale/corp#21867