### PR TITLE
tailscale: use V2 client for dns split nameservers resource

### DIFF
--- a/docs/resources/dns_split_nameservers.md
+++ b/docs/resources/dns_split_nameservers.md
@@ -25,7 +25,7 @@ resource "tailscale_dns_split_nameservers" "sample_split_nameservers" {
 
 ### Required
 
-- `domain` (String) Domain to configure split DNS for. Requests for this domain will be resolved using the provided nameservers.
+- `domain` (String) Domain to configure split DNS for. Requests for this domain will be resolved using the provided nameservers. Changing this will force the resource to be recreated.
 - `nameservers` (Set of String) Devices on your network will use these nameservers to resolve DNS names. IPv4 or IPv6 addresses are accepted.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19
-	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240819223802-3a9fb56052db
+	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240821114300-27aa0bfb4219
 	golang.org/x/tools v0.24.0
 	tailscale.com v1.72.0
 )

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,10 @@ github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19 h
 github.com/tailscale/tailscale-client-go v1.17.1-0.20240729175651-90a1e935cc19/go.mod h1:jbwJyHniK3nyLttwcDTXnfdDQEnADvc4VMOP8hZWnR0=
 github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240819223802-3a9fb56052db h1:sckiiaymnxDtxozA8jGc2cAU1X/0vEmKULvAP8fTS1o=
 github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240819223802-3a9fb56052db/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240820184537-d8366c1105f5 h1:4KAE8ArCbcmTWCn1jMnhos+G4jMhGAJt76rVAWIO6D4=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240820184537-d8366c1105f5/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240821114300-27aa0bfb4219 h1:j51CReIxNS/7ZrFmn5zm5IYoIBg8Or8BL6G3jFC/ZgY=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240821114300-27aa0bfb4219/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/tailscale/resource_dns_split_nameservers_test.go
+++ b/tailscale/resource_dns_split_nameservers_test.go
@@ -1,10 +1,16 @@
 package tailscale_test
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
 )
 
 const testSplitNameservers = `
@@ -24,6 +30,94 @@ func TestProvider_TailscaleSplitDNSNameservers(t *testing.T) {
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_split_nameservers.test_nameservers", testSplitNameservers),
 			testResourceDestroyed("tailscale_dns_split_nameservers.test_nameservers", testSplitNameservers),
+		},
+	})
+}
+
+func TestAccTailscaleDNSSplitNameservers(t *testing.T) {
+	const resourceName = "tailscale_dns_split_nameservers.test_nameservers"
+
+	const testSplitNameserversCreate = `
+		resource "tailscale_dns_split_nameservers" "test_nameservers" {
+			domain = "example.com"
+			nameservers = ["1.2.3.4", "4.5.6.7"]
+		}`
+
+	const testSplitNameserversUpdate = `
+		resource "tailscale_dns_split_nameservers" "test_nameservers" {
+			domain = "sub.example.com"
+			nameservers = ["8.8.9.9"]
+		}`
+
+	const testSplitNameserversUpdateSameDomain = `
+		resource "tailscale_dns_split_nameservers" "test_nameservers" {
+			domain = "sub.example.com"
+			nameservers = ["8.8.7.7", "8.8.9.9"]
+		}`
+
+	checkProperties := func(expected tsclient.SplitDNSResponse) func(client *tsclient.Client, rs *terraform.ResourceState) error {
+		return func(client *tsclient.Client, rs *terraform.ResourceState) error {
+			actual, err := client.DNS().SplitDNS(context.Background())
+			if err != nil {
+				return err
+			}
+
+			if diff := cmp.Diff(actual, expected); diff != "" {
+				return fmt.Errorf("wrong split dns: (-got+want) \n%s", diff)
+			}
+
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties(tsclient.SplitDNSResponse{})),
+		Steps: []resource.TestStep{
+			{
+				Config: testSplitNameserversCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties(tsclient.SplitDNSResponse{
+							"example.com": []string{"1.2.3.4", "4.5.6.7"},
+						}),
+					),
+					resource.TestCheckResourceAttr(resourceName, "domain", "example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "1.2.3.4"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "4.5.6.7"),
+				),
+			},
+			{
+				Config: testSplitNameserversUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties(tsclient.SplitDNSResponse{
+							"sub.example.com": []string{"8.8.9.9"},
+						}),
+					),
+					resource.TestCheckResourceAttr(resourceName, "domain", "sub.example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.9.9"),
+				),
+			},
+			{
+				Config: testSplitNameserversUpdateSameDomain,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties(tsclient.SplitDNSResponse{
+							"sub.example.com": []string{"8.8.7.7", "8.8.9.9"},
+						}),
+					),
+					resource.TestCheckResourceAttr(resourceName, "domain", "sub.example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.7.7"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.9.9"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Updates tailscale/corp#21867

Depends on https://github.com/tailscale/tailscale-client-go/pull/104