### PR TITLE
tailscale: use V2 client for acl data source

### DIFF
--- a/tailscale/data_source_acl.go
+++ b/tailscale/data_source_acl.go
@@ -29,9 +29,9 @@ func dataSourceACL() *schema.Resource {
 }
 
 func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Clients).V1
+	client := m.(*Clients).V2
 
-	acl, err := client.RawACL(ctx)
+	acl, err := client.PolicyFile().Raw(ctx)
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch ACL")
 	}

--- a/tailscale/data_source_acl_test.go
+++ b/tailscale/data_source_acl_test.go
@@ -1,0 +1,49 @@
+package tailscale_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/tailscale/hujson"
+	"github.com/tailscale/terraform-provider-tailscale/tailscale"
+)
+
+func TestAccTailscaleACL(t *testing.T) {
+	resourceName := "data.tailscale_acl.acl"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: `data "tailscale_acl" "acl" {}`,
+				Check: func(s *terraform.State) error {
+					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					acl, err := client.PolicyFile().Raw(context.Background())
+					if err != nil {
+						return fmt.Errorf("unable to get ACL: %s", err)
+					}
+
+					huj, err := hujson.Parse([]byte(acl))
+					if err != nil {
+						return fmt.Errorf("Failed to parse ACL as HuJSON: %s", err)
+					}
+					expected := huj.String()
+
+					rs := s.RootModule().Resources[resourceName].Primary
+					actual := rs.Attributes["hujson"]
+					if diff := cmp.Diff(expected, actual); diff != "" {
+						return fmt.Errorf("wrong ACL (-got, +want): %s", diff)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/tailscale/data_source_acl_test.go
+++ b/tailscale/data_source_acl_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -37,8 +36,8 @@ func TestAccTailscaleACL(t *testing.T) {
 
 					rs := s.RootModule().Resources[resourceName].Primary
 					actual := rs.Attributes["hujson"]
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						return fmt.Errorf("wrong ACL (-got, +want): %s", diff)
+					if err := assertEqual(expected, actual, "wrong ACL"); err != nil {
+						return err
 					}
 
 					return nil

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -189,5 +190,14 @@ func checkPropertiesMatch(resourceName string, s *terraform.State, expected map[
 		}
 	}
 
+	return nil
+}
+
+// assertEqual compares the expected and actual using [cmp.Diff] and reports an
+// error if they're not equal.
+func assertEqual(want, got any, errorMessage string) error {
+	if diff := cmp.Diff(want, got); diff != "" {
+		return fmt.Errorf("%s (-want +got): %s", errorMessage, diff)
+	}
 	return nil
 }

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -186,8 +185,8 @@ func TestAccACL(t *testing.T) {
 				return err
 			}
 
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				return fmt.Errorf("diff found (-got, +want): %s", diff)
+			if err := assertEqual(expected, actual, "wrong ACL"); err != nil {
+				return err
 			}
 
 			return nil

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -2,11 +2,9 @@ package tailscale_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -53,8 +51,8 @@ func TestAccTailscaleDNSNameservers(t *testing.T) {
 				return err
 			}
 
-			if diff := cmp.Diff(actual, expected); diff != "" {
-				return fmt.Errorf("wrong nameservers: (-got+want) \n%s", diff)
+			if err := assertEqual(expected, actual, "wrong nameservers"); err != nil {
+				return err
 			}
 
 			return nil

--- a/tailscale/resource_dns_preferences_test.go
+++ b/tailscale/resource_dns_preferences_test.go
@@ -2,11 +2,9 @@ package tailscale_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -48,8 +46,8 @@ func TestAccTailscaleDNSPreferences(t *testing.T) {
 				return err
 			}
 
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				return fmt.Errorf("diff found (-got, +want): %s", diff)
+			if err := assertEqual(expected, actual, "wrong DNS preferences"); err != nil {
+				return err
 			}
 
 			return nil

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -2,11 +2,9 @@ package tailscale_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -53,8 +51,8 @@ func TestAccTailscaleDNSSearchPaths(t *testing.T) {
 				return err
 			}
 
-			if diff := cmp.Diff(actual, expected); diff != "" {
-				return fmt.Errorf("wrong dns search paths: (-got+want) \n%s", diff)
+			if err := assertEqual(expected, actual, "wrong DNS search paths"); err != nil {
+				return err
 			}
 
 			return nil

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -212,8 +211,8 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 			// don't compare IDs
 			actual.ID = ""
 
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				return fmt.Errorf("diff found (-got, +want): %s", diff)
+			if err := assertEqual(expected, actual, "wrong key"); err != nil {
+				return err
 			}
 
 			return nil

--- a/tailscale/resource_tailnet_settings_test.go
+++ b/tailscale/resource_tailnet_settings_test.go
@@ -2,10 +2,8 @@ package tailscale_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -42,8 +40,8 @@ func TestAccTailscaleTailnetSettings(t *testing.T) {
 				return err
 			}
 
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				return fmt.Errorf("diff found (-got, +want): %s", diff)
+			if err := assertEqual(expected, actual, "wrong Tailnet settings"); err != nil {
+				return err
 			}
 
 			return nil


### PR DESCRIPTION
Updates tailscale/corp#21867