### PR TITLE
tailscale: rename tailscale_test package to tailscale

### DIFF
--- a/tailscale/data_source_4via6_test.go
+++ b/tailscale/data_source_4via6_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"fmt"

--- a/tailscale/data_source_acl_test.go
+++ b/tailscale/data_source_acl_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/tailscale/hujson"
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 func TestAccTailscaleACL(t *testing.T) {
@@ -22,7 +21,7 @@ func TestAccTailscaleACL(t *testing.T) {
 			{
 				Config: `data "tailscale_acl" "acl" {}`,
 				Check: func(s *terraform.State) error {
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					acl, err := client.PolicyFile().Raw(context.Background())
 					if err != nil {
 						return fmt.Errorf("unable to get ACL: %s", err)

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -108,13 +108,13 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	d.SetId(selected.ID)
-	return setProperties(d, DeviceToMap(selected))
+	return setProperties(d, deviceToMap(selected))
 }
 
-// DeviceToMap converts the given device into a map representing the device as a
+// deviceToMap converts the given device into a map representing the device as a
 // resource in Terraform. This omits the "id" which is expected to be set
 // using [schema.ResourceData.SetId].
-func DeviceToMap(device *tsclient.Device) map[string]any {
+func deviceToMap(device *tsclient.Device) map[string]any {
 	return map[string]any{
 		"name":      device.Name,
 		"hostname":  device.Hostname,

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -82,7 +82,7 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interf
 			continue
 		}
 
-		m := DeviceToMap(&device)
+		m := deviceToMap(&device)
 		m["id"] = device.ID
 		deviceMaps = append(deviceMaps, m)
 	}

--- a/tailscale/data_source_user.go
+++ b/tailscale/data_source_user.go
@@ -96,13 +96,13 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 	}
 
 	d.SetId(user.ID)
-	return setProperties(d, UserToMap(user))
+	return setProperties(d, userToMap(user))
 }
 
-// UserToMap converts the given user into a map representing the user as a
+// userToMap converts the given user into a map representing the user as a
 // resource in Terraform. This omits the "id" which is expected to be set
 // using [schema.ResourceData.SetId].
-func UserToMap(user *tsclient.User) map[string]any {
+func userToMap(user *tsclient.User) map[string]any {
 	return map[string]any{
 		"display_name":        user.DisplayName,
 		"login_name":          user.LoginName,

--- a/tailscale/data_source_users.go
+++ b/tailscale/data_source_users.go
@@ -76,7 +76,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	userMaps := make([]map[string]interface{}, 0, len(users))
 	for _, user := range users {
-		m := UserToMap(&user)
+		m := userToMap(&user)
 		m["id"] = user.ID
 		userMaps = append(userMaps, m)
 	}

--- a/tailscale/data_source_users_test.go
+++ b/tailscale/data_source_users_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"
@@ -8,8 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 func TestAccTailscaleUsers(t *testing.T) {
@@ -27,7 +25,7 @@ func TestAccTailscaleUsers(t *testing.T) {
 			{
 				Config: `data "tailscale_users" "all_users" {}`,
 				Check: func(s *terraform.State) error {
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					users, err := client.Users().List(context.Background(), nil, nil)
 					if err != nil {
 						return fmt.Errorf("unable to list users: %s", err)
@@ -35,7 +33,7 @@ func TestAccTailscaleUsers(t *testing.T) {
 
 					usersByID := make(map[string]map[string]any)
 					for _, user := range users {
-						m := tailscale.UserToMap(&user)
+						m := userToMap(&user)
 						m["id"] = user.ID
 						usersByID[user.ID] = m
 					}
@@ -97,14 +95,14 @@ func TestAccTailscaleUsers(t *testing.T) {
 			{
 				Config: userDataSources.String(),
 				Check: func(s *terraform.State) error {
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					users, err := client.Users().List(context.Background(), nil, nil)
 					if err != nil {
 						return fmt.Errorf("unable to list users: %s", err)
 					}
 
 					for _, user := range users {
-						expected := tailscale.UserToMap(&user)
+						expected := userToMap(&user)
 						expected["id"] = user.ID
 						resourceName := fmt.Sprintf("data.tailscale_user.%s", user.ID)
 						if err := checkPropertiesMatch(resourceName, s, expected); err != nil {

--- a/tailscale/datasource_devices_test.go
+++ b/tailscale/datasource_devices_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"
@@ -8,8 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 func TestAccTailscaleDevices(t *testing.T) {
@@ -31,7 +29,7 @@ func TestAccTailscaleDevices(t *testing.T) {
 			{
 				Config: `data "tailscale_devices" "all_devices" {}`,
 				Check: func(s *terraform.State) error {
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					devices, err := client.Devices().List(context.Background())
 					if err != nil {
 						return fmt.Errorf("unable to list devices: %s", err)
@@ -39,7 +37,7 @@ func TestAccTailscaleDevices(t *testing.T) {
 
 					devicesByID := make(map[string]map[string]any)
 					for _, device := range devices {
-						m := tailscale.DeviceToMap(&device)
+						m := deviceToMap(&device)
 						m["id"] = device.ID
 						devicesByID[device.ID] = m
 					}
@@ -105,14 +103,14 @@ func TestAccTailscaleDevices(t *testing.T) {
 			{
 				Config: devicesDataSources.String(),
 				Check: func(s *terraform.State) error {
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					devices, err := client.Devices().List(context.Background())
 					if err != nil {
 						return fmt.Errorf("unable to list devices: %s", err)
 					}
 
 					for _, device := range devices {
-						expected := tailscale.DeviceToMap(&device)
+						expected := deviceToMap(&device)
 						expected["id"] = device.ID
 						var nameComponent string
 						if device.Hostname != "" {

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"
@@ -14,12 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
-var testClients *tailscale.Clients
+var testClients *Clients
 var testServer *TestServer
-var testAccProvider = tailscale.Provider()
+var testAccProvider = Provider()
 
 // testAccPreCheck ensures that the TAILSCALE_API_KEY and TAILSCALE_BASE_URL variables
 // are set and configures the provider. This must be called before running acceptance
@@ -53,19 +52,19 @@ func testAccProviderFactories(t *testing.T) map[string]func() (*schema.Provider,
 
 	return map[string]func() (*schema.Provider, error){
 		"tailscale": func() (*schema.Provider, error) {
-			return tailscale.Provider(), nil
+			return Provider(), nil
 		},
 	}
 }
 
 func TestProvider(t *testing.T) {
-	if err := tailscale.Provider().InternalValidate(); err != nil {
+	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_Implemented(t *testing.T) {
-	var _ *schema.Provider = tailscale.Provider()
+	var _ *schema.Provider = Provider()
 }
 
 func testProviderFactories(t *testing.T) map[string]func() (*schema.Provider, error) {
@@ -74,7 +73,7 @@ func testProviderFactories(t *testing.T) map[string]func() (*schema.Provider, er
 	testClients, testServer = NewTestHarness(t)
 	return map[string]func() (*schema.Provider, error){
 		"tailscale": func() (*schema.Provider, error) {
-			return tailscale.Provider(func(p *schema.Provider) {
+			return Provider(func(p *schema.Provider) {
 				// Set up a test harness for the provider
 				p.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
 					return testClients, nil
@@ -140,7 +139,7 @@ func checkResourceRemoteProperties(resourceName string, check func(client *tscli
 			return fmt.Errorf("resource has no ID set")
 		}
 
-		client := testAccProvider.Meta().(*tailscale.Clients).V2
+		client := testAccProvider.Meta().(*Clients).V2
 		return check(client, rs)
 	}
 }
@@ -156,7 +155,7 @@ func checkResourceDestroyed(resourceName string, check func(client *tsclient.Cli
 			return fmt.Errorf("resource has no ID set")
 		}
 
-		client := testAccProvider.Meta().(*tailscale.Clients).V2
+		client := testAccProvider.Meta().(*Clients).V2
 		return check(client, rs)
 	}
 }

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_contacts_test.go
+++ b/tailscale/resource_contacts_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 func TestAccTailscaleDeviceTags(t *testing.T) {
@@ -68,7 +67,7 @@ func TestAccTailscaleDeviceTags(t *testing.T) {
 			{
 				PreConfig: func() {
 					// Set up ACLs to allow the required tags
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					err := client.PolicyFile().Set(context.Background(), `
 					{
 					    "tagOwners": {

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_dns_preferences_test.go
+++ b/tailscale/resource_dns_preferences_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_dns_split_nameservers_test.go
+++ b/tailscale/resource_dns_split_nameservers_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_logstream_configuration_test.go
+++ b/tailscale/resource_logstream_configuration_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_posture_integration_test.go
+++ b/tailscale/resource_posture_integration_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 const testTailnetKey = `
@@ -240,7 +239,7 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 			{
 				PreConfig: func() {
 					// Set up ACLs to allow the required tags
-					client := testAccProvider.Meta().(*tailscale.Clients).V2
+					client := testAccProvider.Meta().(*Clients).V2
 					err := client.PolicyFile().Set(context.Background(), `
 					{
 					    "tagOwners": {

--- a/tailscale/resource_tailnet_settings_test.go
+++ b/tailscale/resource_tailnet_settings_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/resource_webhook_test.go
+++ b/tailscale/resource_webhook_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"context"

--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -1,4 +1,4 @@
-package tailscale_test
+package tailscale
 
 import (
 	"bytes"
@@ -15,7 +15,6 @@ import (
 
 	tsclientv1 "github.com/tailscale/tailscale-client-go/tailscale"
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
-	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 type TestServer struct {
@@ -29,7 +28,7 @@ type TestServer struct {
 	ResponseBody interface{}
 }
 
-func NewTestHarness(t *testing.T) (*tailscale.Clients, *TestServer) {
+func NewTestHarness(t *testing.T) (*Clients, *TestServer) {
 	t.Helper()
 
 	testServer := &TestServer{
@@ -69,7 +68,7 @@ func NewTestHarness(t *testing.T) (*tailscale.Clients, *TestServer) {
 		Tailnet: "example.com",
 	}
 
-	return &tailscale.Clients{client, clientV2}, testServer
+	return &Clients{client, clientV2}, testServer
 }
 
 func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This allows the reuse of private functions like deviceToMap between the core package and the tests.

Updates tailscale/corp#21867