### PR TITLE
{all}: check for license headers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,11 @@ jobs:
         run: |
           git add .
           git diff --staged --exit-code
+
+  licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: check licenses
+        run: ./scripts/check_license_headers.sh .

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 David Bond
+Copyright (c) 2024 Tailscale Inc & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 //go:generate tfplugindocs
 package main
 

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+#
+# Copyright (c) David Bond, Tailscale Inc, & Contributors
+# SPDX-License-Identifier: MIT
+
+# check_license_headers.sh checks that all Go files in the given
+# directory tree have a correct-looking license header.
+
+check_file() {
+    got=$1
+
+    want=$(cat <<EOF
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+EOF
+    )
+    if [ "$got" = "$want" ]; then
+        return 0
+    fi
+    return 1
+}
+
+if [ $# != 1 ]; then
+    echo "Usage: $0 rootdir" >&2
+    exit 1
+fi
+
+fail=0
+for file in $(find $1 \( -name '*.go' -or -name '*.tsx' -or -name '*.ts' -not -name '*.config.ts' \) -not -path '*/.git/*' -not -path '*/node_modules/*'); do
+    case $file in
+        $1/tempfork/*)
+            # Skip, tempfork of third-party code
+        ;;
+        $1/wgengine/router/ifconfig_windows.go)
+            # WireGuard copyright.
+        ;;
+        $1/cmd/tailscale/cli/authenticode_windows.go)
+            # WireGuard copyright.
+        ;;
+        *_string.go)
+          # Generated file from go:generate stringer
+        ;;
+        $1/control/controlbase/noiseexplorer_test.go)
+          # Noiseexplorer.com copyright.
+        ;;
+        */zsyscall_windows.go)
+            # Generated syscall wrappers
+        ;;
+        $1/util/winutil/subprocess_windows_test.go)
+            # Subprocess test harness code
+        ;;
+        $1/util/winutil/testdata/testrestartableprocesses/main.go)
+            # Subprocess test harness code
+        ;;
+        *$1/k8s-operator/apis/v1alpha1/zz_generated.deepcopy.go)
+            # Generated kube deepcopy funcs file starts with a Go build tag + an empty line
+            header="$(head -5 $file | tail -n+3 )"
+        ;;
+        $1/derp/xdp/bpf_bpfe*.go)
+            # Generated eBPF management code
+        ;;
+        *)
+           header="$(head -2 $file)"
+        ;;
+    esac
+    if [ ! -z "$header" ]; then
+            if ! check_file "$header"; then
+                fail=1
+                echo "${file#$1/} doesn't have the right copyright header:"
+                echo "$header" | sed -e 's/^/    /g'
+            fi
+    fi
+done
+
+if [ $fail -ne 0 ]; then
+    exit 1
+fi

--- a/tailscale/data_source_4via6.go
+++ b/tailscale/data_source_4via6.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_4via6_test.go
+++ b/tailscale/data_source_4via6_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_acl.go
+++ b/tailscale/data_source_acl.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_acl_test.go
+++ b/tailscale/data_source_acl_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_user.go
+++ b/tailscale/data_source_user.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_users.go
+++ b/tailscale/data_source_users.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/data_source_users_test.go
+++ b/tailscale/data_source_users_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/datasource_devices_test.go
+++ b/tailscale/datasource_devices_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 // Package tailscale describes the resources and data sources provided by the terraform provider. Each resource
 // or data source is described within its own file.
 package tailscale

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_contacts.go
+++ b/tailscale/resource_contacts.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_contacts_test.go
+++ b/tailscale/resource_contacts_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_preferences_test.go
+++ b/tailscale/resource_dns_preferences_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_dns_split_nameservers_test.go
+++ b/tailscale/resource_dns_split_nameservers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_logstream_configuration.go
+++ b/tailscale/resource_logstream_configuration.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_logstream_configuration_test.go
+++ b/tailscale/resource_logstream_configuration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_posture_integration_test.go
+++ b/tailscale/resource_posture_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_tailnet_settings.go
+++ b/tailscale/resource_tailnet_settings.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_tailnet_settings_test.go
+++ b/tailscale/resource_tailnet_settings_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_webhook.go
+++ b/tailscale/resource_webhook.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/resource_webhook_test.go
+++ b/tailscale/resource_webhook_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 package tailscale
 
 import (

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,6 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
 //go:build tools
 
 package tools


### PR DESCRIPTION
Check license headers in CI runs with scripts/check_license_headers.sh. Also adjust LICENSE to reflect the current authors.

Updates #cleanup
