### PR TITLE
tailscale: update to new tailscale client OAuth config pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
-	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240826162147-08f128738726
+	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240916214524-e89a1ab786c8
 	golang.org/x/tools v0.24.0
 	tailscale.com v1.72.1
 )

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29XwJucQo73FrleVK6t4kYz4NVhp34Yw=
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240826162147-08f128738726 h1:LmzY47aAgi6MhlBe8iar0Syp1gODiChMK2UGWplRjG0=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240826162147-08f128738726/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240916214524-e89a1ab786c8 h1:TWFePmmkhpLyR/HK4Y4eA+WQE/AkQLLYoDkGh5MvBTA=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240916214524-e89a1ab786c8/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -161,8 +161,12 @@ func providerConfigure(_ context.Context, provider *schema.Provider, d *schema.R
 			BaseURL:   parsedBaseURL,
 			UserAgent: userAgent,
 			Tailnet:   tailnet,
+			HTTP: tsclient.OAuthConfig{
+				ClientID:     oauthClientID,
+				ClientSecret: oauthClientSecret,
+				Scopes:       oauthScopes,
+			}.HTTPClient(),
 		}
-		client.UseOAuth(oauthClientID, oauthClientSecret, oauthScopes)
 
 		return client, nil
 	}


### PR DESCRIPTION
Update tailscale-client-go dependency and modify OAuth usage to work with the breaking change in OAuth API that was introduced.

Updates https://github.com/tailscale/corp/issues/21867