### PR TITLE
tailscale: pass base URL to OAuthConfig

### DIFF
--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -162,6 +162,7 @@ func providerConfigure(_ context.Context, provider *schema.Provider, d *schema.R
 			UserAgent: userAgent,
 			Tailnet:   tailnet,
 			HTTP: tsclient.OAuthConfig{
+				BaseURL:      parsedBaseURL.String(),
 				ClientID:     oauthClientID,
 				ClientSecret: oauthClientSecret,
 				Scopes:       oauthScopes,


### PR DESCRIPTION
Pass the `parsedBaseURL` to `tsclient.OAuthConfig`. The base URL the OAuth client used for attempting to generate tokens was always the default URL previously which causes issues if the base URL for the provider and the rest of the tailscale client is set to something else.

Fixes https://github.com/tailscale/terraform-provider-tailscale/issues/438
