### PR TITLE
tailscale: add acceptance tests for new import logic

### DIFF
--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -78,6 +78,11 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "true"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -98,6 +98,11 @@ func TestAccTailscaleDeviceTags(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "tags.*", "tag:c"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -86,6 +86,11 @@ func TestAccTailscaleDNSNameservers(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "1.1.1.1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -86,6 +86,11 @@ func TestAccTailscaleDNSSearchPaths(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "search_paths.*", "example.com"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/tailscale/resource_logstream_configuration.go
+++ b/tailscale/resource_logstream_configuration.go
@@ -20,6 +20,9 @@ func resourceLogstreamConfiguration() *schema.Resource {
 		CreateContext: resourceLogstreamConfigurationCreate,
 		UpdateContext: resourceLogstreamUpdate,
 		DeleteContext: resourceLogstreamDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"log_type": {
 				Type:        schema.TypeString,

--- a/tailscale/resource_logstream_configuration_test.go
+++ b/tailscale/resource_logstream_configuration_test.go
@@ -141,6 +141,12 @@ func TestAccTailscaleLogstreamConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token", "some-token"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
 		},
 	})
 }

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -20,6 +20,9 @@ func resourcePostureIntegration() *schema.Resource {
 		CreateContext: resourcePostureIntegrationCreate,
 		UpdateContext: resourcePostureIntegrationUpdate,
 		DeleteContext: resourcePostureIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"posture_provider": {
 				Type:        schema.TypeString,

--- a/tailscale/resource_posture_integration_test.go
+++ b/tailscale/resource_posture_integration_test.go
@@ -128,6 +128,12 @@ func TestAccTailscalePostureIntegration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "client_secret", "test-secret3"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
Add acceptance tests to exercise import logic that was recently added for `device_key`, `device_subnet_routes`, `dns_nameservers`, and `dns_search_paths`.

Updates #TODO
