### PR TITLE
go.mod, tailscale: update to latest tailscale-client-go

### DIFF
--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -34,6 +34,7 @@ resource "tailscale_tailnet_key" "sample_key" {
 - `recreate_if_invalid` (String) Determines whether the key should be created again if it becomes invalid. By default, reusable keys will be recreated, but single-use keys will not. Possible values: 'always', 'never'.
 - `reusable` (Boolean) Indicates if the key is reusable or single-use. Defaults to `false`.
 - `tags` (Set of String) List of tags to apply to the machines authenticated by the key.
+- `user_id` (String) ID of the user who created this key, empty for keys created by OAuth clients.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
-	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240916214524-e89a1ab786c8
+	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20241028210109-bd4d815eb293
 	golang.org/x/tools v0.24.0
 	tailscale.com v1.76.3
 )

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29XwJucQo73FrleVK6t4kYz4NVhp34Yw=
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240916214524-e89a1ab786c8 h1:TWFePmmkhpLyR/HK4Y4eA+WQE/AkQLLYoDkGh5MvBTA=
-github.com/tailscale/tailscale-client-go/v2 v2.0.0-20240916214524-e89a1ab786c8/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20241028210109-bd4d815eb293 h1:qguJy85YoqTEdGznTqbOSh+GZgTvBpOCriN9/HhayK0=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20241028210109-bd4d815eb293/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/tailscale/data_source_acl.go
+++ b/tailscale/data_source_acl.go
@@ -39,7 +39,7 @@ func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, m interface{
 	if err != nil {
 		return diagnosticsError(err, "Failed to fetch ACL")
 	}
-	huj, err := hujson.Parse([]byte(acl))
+	huj, err := hujson.Parse([]byte(acl.HuJSON))
 	if err != nil {
 		return diagnosticsError(err, "Failed to parse ACL as HuJSON")
 	}

--- a/tailscale/data_source_acl_test.go
+++ b/tailscale/data_source_acl_test.go
@@ -31,7 +31,7 @@ func TestAccTailscaleACL(t *testing.T) {
 						return fmt.Errorf("unable to get ACL: %s", err)
 					}
 
-					huj, err := hujson.Parse([]byte(acl))
+					huj, err := hujson.Parse([]byte(acl.HuJSON))
 					if err != nil {
 						return fmt.Errorf("Failed to parse ACL as HuJSON: %s", err)
 					}

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -105,7 +105,7 @@ func resourceACLRead(ctx context.Context, d *schema.ResourceData, m interface{})
 		return diagnosticsError(err, "Failed to fetch ACL")
 	}
 
-	if err := d.Set("acl", acl); err != nil {
+	if err := d.Set("acl", acl.HuJSON); err != nil {
 		return diag.FromErr(err)
 	}
 	return nil

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -188,6 +188,8 @@ func TestAccACL(t *testing.T) {
 				return err
 			}
 
+			// Clear out ETag before comparing to expected.
+			actual.ETag = ""
 			if err := assertEqual(expected, actual, "wrong ACL"); err != nil {
 				return err
 			}

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -102,6 +102,12 @@ func resourceTailnetKey() *schema.Resource {
 					}
 				},
 			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "ID of the user who created this key, empty for keys created by OAuth clients.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -255,6 +261,10 @@ func resourceTailnetKeyRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	if err = d.Set("invalid", key.Invalid); err != nil {
 		return diagnosticsError(err, "Failed to set 'invalid'")
+	}
+
+	if err = d.Set("user_id", key.UserID); err != nil {
+		return diagnosticsError(err, "Failed to set 'user_id'")
 	}
 
 	return nil

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -213,6 +213,9 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 			// don't compare IDs
 			actual.ID = ""
 
+			// don't compare user IDs
+			actual.UserID = ""
+
 			if err := assertEqual(expected, actual, "wrong key"); err != nil {
 				return err
 			}


### PR DESCRIPTION
Update acl datasource and resource to use new  type.

Updates tailscale/tailscale-client-go#119