### PR TITLE
resource_tailscale_tailnet_key: prevent recreate when expiry is undefined

### DIFF
--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -63,6 +63,7 @@ func resourceTailnetKey() *schema.Resource {
 			"expiry": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "The expiry of the key in seconds. Defaults to `7776000` (90 days).",
 				ForceNew:    true,
 			},

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -182,7 +182,6 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 			ephemeral = true
 			preauthorized = true
 			tags = ["tag:a"]
-			expiry = 3600
 			description = "Test key"
 		}`
 
@@ -231,7 +230,7 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 	var expectedKey tailscale.Key
 	expectedKey.KeyType = "auth"
 	expectedKey.Description = "Test key"
-	expectedKey.ExpirySeconds = toPtr(time.Duration(3600))
+	expectedKey.ExpirySeconds = toPtr(time.Duration(7776000))
 	expectedKey.Capabilities.Devices.Create.Reusable = true
 	expectedKey.Capabilities.Devices.Create.Ephemeral = true
 	expectedKey.Capabilities.Devices.Create.Preauthorized = true
@@ -268,15 +267,20 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 				Config: testTailnetKeyCreate,
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceRemoteProperties(resourceName,
-						checkProperties(&expectedKey, 3600),
+						checkProperties(&expectedKey, 7776000),
 					),
 					resource.TestCheckResourceAttr(resourceName, "reusable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ephemeral", "true"),
 					resource.TestCheckResourceAttr(resourceName, "preauthorized", "true"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "tags.*", "tag:a"),
-					resource.TestCheckResourceAttr(resourceName, "expiry", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "expiry", "7776000"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test key"),
 				),
+			},
+			{
+				Config:             testTailnetKeyCreate,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 			{
 				Config: testTailnetKeyUpdate,


### PR DESCRIPTION
**What this PR does / why we need it**:

Oversight when we added expiry on the read operation to support imports. We need to mark it as computed so the BE-generated value is used if it's not specified in the schema.

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #520

**Special notes for your reviewer**:

Demo:


https://github.com/user-attachments/assets/9743b135-af98-4cf6-9aac-706542d5ce3c


