### PR TITLE
README.md: add callout to the versioning best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ make testacc_local
 
 ## Releasing
 
+Our releases follow sem-ver format and follow the recommended versioning practices [as documented by HashiCorp](https://developer.hashicorp.com/terraform/plugin/best-practices/versioning). 
+
 Pushing a tag of the format `vX.Y.Z` will trigger the [release workflow](./.github/workflows/release.yml) which uses [goreleaser](https://github.com/goreleaser/goreleaser) to build and sign artifacts and generate a [GitHub release](https://github.com/tailscale/terraform-provider-tailscale/releases).
 
 GitHub releases are pulled in and served by the [HashiCorp Terrafrom](https://registry.terraform.io/providers/tailscale/tailscale/latest) and [OpenTofu](https://github.com/opentofu/registry/blob/main/providers/t/tailscale/tailscale.json) registries for usage of the provider via Terraform or OpenTofu.


### PR DESCRIPTION
Add a reference to the versioning best practices documentation from HashiCorp in the release section of the README.

Updates #cleanup
