### PR TITLE
.github/workflows: run go mod tidy as part of format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,11 @@ jobs:
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
 
-      - name: Format code
+      - name: Format code, clean up imports and module dependencies
         run: |
           go fmt ./...
           goimports -w -local github.com/tailscale .
+          go mod tidy
 
       - name: Check for uncommitted changes
         run: |


### PR DESCRIPTION
[Fails](https://github.com/tailscale/terraform-provider-tailscale/actions/runs/18400692675/job/52429036410?pr=563) the `format` step in the pipeline when `go mod tidy` should have been run locally but wasn't.

Fixes #562
