### PR TITLE
docs: fix spelling of network flow logs

### DIFF
--- a/docs/resources/tailnet_settings.md
+++ b/docs/resources/tailnet_settings.md
@@ -37,7 +37,7 @@ resource "tailscale_tailnet_settings" "sample_tailnet_settings" {
 - `devices_auto_updates_on` (Boolean) Whether auto updates are enabled for devices that belong to this tailnet
 - `devices_key_duration_days` (Number) The key expiry duration for devices on this tailnet
 - `https_enabled` (Boolean) Whether provisioning of HTTPS certificates is enabled for the tailnet
-- `network_flow_logging_on` (Boolean) Whether network flog logs are enabled for the tailnet
+- `network_flow_logging_on` (Boolean) Whether network flow logs are enabled for the tailnet
 - `posture_identity_collection_on` (Boolean) Whether identity collection is enabled for device posture integrations for the tailnet
 - `regional_routing_on` (Boolean) Whether regional routing is enabled for the tailnet
 - `users_approval_on` (Boolean) Whether user approval is enabled for this tailnet

--- a/tailscale/resource_tailnet_settings.go
+++ b/tailscale/resource_tailnet_settings.go
@@ -77,7 +77,7 @@ func resourceTailnetSettings() *schema.Resource {
 			},
 			"network_flow_logging_on": {
 				Type:        schema.TypeBool,
-				Description: "Whether network flog logs are enabled for the tailnet",
+				Description: "Whether network flow logs are enabled for the tailnet",
 				Optional:    true,
 				Computed:    true,
 			},


### PR DESCRIPTION
Had been misspelled as "network flog logs".

Fixes #569