### PR TITLE
tailscale_device_authorization: hande missing device on state refresh

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -42,7 +42,11 @@ func resourceDeviceAuthorizationRead(ctx context.Context, d *schema.ResourceData
 	deviceID := d.Id()
 
 	device, err := client.Devices().Get(ctx, deviceID)
-	if err != nil {
+	switch {
+	case tailscale.IsNotFound(err):
+		d.SetId("")
+		return nil
+	case err != nil:
 		return diagnosticsError(err, "Failed to fetch device")
 	}
 


### PR DESCRIPTION
Remove authorization resource for a devices if device request returns 404.

Fixes #585
