### PR TITLE
resource_dns_configuration: add `magic_dns_name` attr

### DIFF
--- a/docs/resources/dns_configuration.md
+++ b/docs/resources/dns_configuration.md
@@ -59,6 +59,7 @@ resource "tailscale_dns_configuration" "sample_configuration" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `magic_dns_name` (String) The tailnet/MagicDNS domain name. Null if disabled or undeterminable.
 
 <a id="nestedblock--nameservers"></a>
 ### Nested Schema for `nameservers`


### PR DESCRIPTION
It's not presently possible to determine the tailnet/MagicDNS name without a `tailscale_device(s)` data source and some string manipulation.

Ideally, there'd be an API for this directy, but in lieu of that this commit moves the device list/error (or 0 device) handling/string manipulation into the provider; so that the terraform config can more cleanly and naturally read from:
  tailscale_dns_configuration.x.magic_dns_name

to get the name like 'hyperactive-sloth.ts.net' directly.