### PR TITLE
examples: fix JSON and HuJSON ACL syntax

### DIFF
--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -19,7 +19,7 @@ If tests are defined in the policy file (the top-level "tests" section), policy 
 ```terraform
 resource "tailscale_acl" "as_json" {
   acl = jsonencode({
-    grants : [
+    grants = [
       {
         // Allow all users access to all ports.
         src = ["*"],
@@ -37,9 +37,9 @@ resource "tailscale_acl" "as_hujson" {
     "grants": [
       {
         // Allow all users access to all ports.
-        "src" = ["*"],
-        "dst" = ["*"],
-        "ip"  = ["*"],
+        "src": ["*"],
+        "dst": ["*"],
+        "ip": ["*"],
       },
     ],
   }

--- a/examples/resources/tailscale_acl/resource.tf
+++ b/examples/resources/tailscale_acl/resource.tf
@@ -1,6 +1,6 @@
 resource "tailscale_acl" "as_json" {
   acl = jsonencode({
-    grants : [
+    grants = [
       {
         // Allow all users access to all ports.
         src = ["*"],
@@ -18,9 +18,9 @@ resource "tailscale_acl" "as_hujson" {
     "grants": [
       {
         // Allow all users access to all ports.
-        "src" = ["*"],
-        "dst" = ["*"],
-        "ip"  = ["*"],
+        "src": ["*"],
+        "dst": ["*"],
+        "ip": ["*"],
       },
     ],
   }


### PR DESCRIPTION
The ACL example includes mixed syntax for the JSON case, and invalid syntax for the HuJSON case. This commit fixes both.