### PR TITLE
tailscale: explicitly document all enum values

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -21,8 +21,8 @@ data "tailscale_users" "all-users" {}
 
 ### Optional
 
-- `role` (String) Filters the users list to elements whose role is the provided value.
-- `type` (String) Filters the users list to elements whose type is the provided value.
+- `role` (String) Filter the results to only include users with a specific role. Valid values are `owner`, `member`, `admin`, `it-admin`, `network-admin`, `billing-admin`, and `auditor`.
+- `type` (String) Filter the results to only include users of a specific type. Valid values are `member` or `shared`.
 
 ### Read-Only
 

--- a/docs/resources/logstream_configuration.md
+++ b/docs/resources/logstream_configuration.md
@@ -53,14 +53,14 @@ resource "tailscale_logstream_configuration" "sample_logstream_configuration_s3_
 
 ### Required
 
-- `destination_type` (String) The type of system to which logs are being streamed.
-- `log_type` (String) The type of log that is streamed to this endpoint. Either `configuration` for configuration audit logs, or `network` for network flow logs.
+- `destination_type` (String) The type of SIEM platform to stream to. Valid values are `axiom`, `cribl`, `datadog`, `elastic`, `panther`, `splunk`, and `s3`.
+- `log_type` (String) The type of logs to stream. Valid values are `configuration` (configuration audit logs) and `network` (network flow logs).
 
 ### Optional
 
-- `compression_format` (String) The compression algorithm with which to compress logs. One of `none`, `zstd` or `gzip`. Defaults to `none`.
+- `compression_format` (String) The compression algorithm used for logs. Valid values are `none`, `zstd` or `gzip`. Defaults to `none`.
 - `s3_access_key_id` (String) The S3 access key ID. Required if destination_type is s3 and s3_authentication_type is 'accesskey'.
-- `s3_authentication_type` (String) What type of authentication to use for S3. Required if destination_type is 's3'. Tailscale recommends using 'rolearn'.
+- `s3_authentication_type` (String) The type of authentication to use for S3. Required if destination_type is `s3`. Valid values are `accesskey` and `rolearn`. Tailscale recommends using `rolearn`.
 - `s3_bucket` (String) The S3 bucket name. Required if destination_type is 's3'.
 - `s3_external_id` (String) The AWS External ID that Tailscale supplies when authenticating using role-based authentication. Required if destination_type is 's3' and s3_authentication_type is 'rolearn'. This can be obtained via the tailscale_aws_external_id resource.
 - `s3_key_prefix` (String) An optional S3 key prefix to prepend to the auto-generated S3 key name.

--- a/docs/resources/posture_integration.md
+++ b/docs/resources/posture_integration.md
@@ -27,7 +27,7 @@ resource "tailscale_posture_integration" "sample_posture_integration" {
 ### Required
 
 - `client_secret` (String) The secret (auth key, token, etc.) used to authenticate with the provider.
-- `posture_provider` (String) The type of posture integration data provider.
+- `posture_provider` (String) The third-party provider for posture data. Valid values are `falcon`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.
 
 ### Optional
 

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -26,11 +26,11 @@ resource "tailscale_webhook" "sample_webhook" {
 ### Required
 
 - `endpoint_url` (String) The endpoint to send webhook events to.
-- `subscriptions` (Set of String) The Tailscale events to subscribe this webhook to. See https://tailscale.com/kb/1213/webhooks#events for the list of valid events.
+- `subscriptions` (Set of String) The set of events that trigger this webhook. For a full list of event types, see the [webhooks documentation](https://tailscale.com/kb/1213/webhooks#events).
 
 ### Optional
 
-- `provider_type` (String) The provider type of the endpoint URL. Also referred to as the 'destination' for the webhook in the admin panel. Webhook event payloads are formatted according to the provider type if it is set to a known value. Must be one of `slack`, `mattermost`, `googlechat`, or `discord` if set.
+- `provider_type` (String) The provider type of the endpoint URL. This determines the payload format sent to the destination. Valid values are `slack`, `mattermost`, `googlechat`, and `discord`.
 
 ### Read-Only
 

--- a/tailscale/data_source_users.go
+++ b/tailscale/data_source_users.go
@@ -21,7 +21,7 @@ func dataSourceUsers() *schema.Resource {
 			"type": {
 				Optional:    true,
 				Type:        schema.TypeString,
-				Description: "Filters the users list to elements whose type is the provided value.",
+				Description: "Filter the results to only include users of a specific type. Valid values are `member` or `shared`.",
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(tailscale.UserTypeMember),
@@ -33,7 +33,7 @@ func dataSourceUsers() *schema.Resource {
 			"role": {
 				Optional:    true,
 				Type:        schema.TypeString,
-				Description: "Filters the users list to elements whose role is the provided value.",
+				Description: "Filter the results to only include users with a specific role. Valid values are `owner`, `member`, `admin`, `it-admin`, `network-admin`, `billing-admin`, and `auditor`.",
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(tailscale.UserRoleOwner),

--- a/tailscale/resource_logstream_configuration.go
+++ b/tailscale/resource_logstream_configuration.go
@@ -26,7 +26,7 @@ func resourceLogstreamConfiguration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"log_type": {
 				Type:        schema.TypeString,
-				Description: "The type of log that is streamed to this endpoint. Either `configuration` for configuration audit logs, or `network` for network flow logs.",
+				Description: "The type of logs to stream. Valid values are `configuration` (configuration audit logs) and `network` (network flow logs).",
 				Required:    true,
 				ForceNew:    true,
 				ValidateFunc: validation.StringInSlice(
@@ -39,16 +39,16 @@ func resourceLogstreamConfiguration() *schema.Resource {
 			},
 			"destination_type": {
 				Type:        schema.TypeString,
-				Description: "The type of system to which logs are being streamed.",
+				Description: "The type of SIEM platform to stream to. Valid values are `axiom`, `cribl`, `datadog`, `elastic`, `panther`, `splunk`, and `s3`.",
 				Required:    true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
-						string(tailscale.LogstreamSplunkEndpoint),
+						string(tailscale.LogstreamAxiomEndpoint),
+						string(tailscale.LogstreamDatadogEndpoint),
+						string(tailscale.LogstreamCriblEndpoint),
 						string(tailscale.LogstreamElasticEndpoint),
 						string(tailscale.LogstreamPantherEndpoint),
-						string(tailscale.LogstreamCriblEndpoint),
-						string(tailscale.LogstreamDatadogEndpoint),
-						string(tailscale.LogstreamAxiomEndpoint),
+						string(tailscale.LogstreamSplunkEndpoint),
 						string(tailscale.LogstreamS3Endpoint),
 					},
 					false),
@@ -77,7 +77,7 @@ func resourceLogstreamConfiguration() *schema.Resource {
 			},
 			"compression_format": {
 				Type:        schema.TypeString,
-				Description: "The compression algorithm with which to compress logs. One of `none`, `zstd` or `gzip`. Defaults to `none`.",
+				Description: "The compression algorithm used for logs. Valid values are `none`, `zstd` or `gzip`. Defaults to `none`.",
 				Optional:    true,
 				Default:     string(tailscale.CompressionFormatNone),
 				ValidateFunc: validation.StringInSlice(
@@ -106,7 +106,7 @@ func resourceLogstreamConfiguration() *schema.Resource {
 			},
 			"s3_authentication_type": {
 				Type:        schema.TypeString,
-				Description: "What type of authentication to use for S3. Required if destination_type is 's3'. Tailscale recommends using 'rolearn'.",
+				Description: "The type of authentication to use for S3. Required if destination_type is `s3`. Valid values are `accesskey` and `rolearn`. Tailscale recommends using `rolearn`.",
 				Optional:    true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -26,7 +26,7 @@ func resourcePostureIntegration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"posture_provider": {
 				Type:        schema.TypeString,
-				Description: "The type of posture integration data provider.",
+				Description: "The third-party provider for posture data. Valid values are `falcon`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.",
 				Required:    true,
 				ForceNew:    true,
 				ValidateFunc: validation.StringInSlice(

--- a/tailscale/resource_webhook.go
+++ b/tailscale/resource_webhook.go
@@ -32,7 +32,7 @@ func resourceWebhook() *schema.Resource {
 			},
 			"provider_type": {
 				Type:        schema.TypeString,
-				Description: "The provider type of the endpoint URL. Also referred to as the 'destination' for the webhook in the admin panel. Webhook event payloads are formatted according to the provider type if it is set to a known value. Must be one of `slack`, `mattermost`, `googlechat`, or `discord` if set.",
+				Description: "The provider type of the endpoint URL. This determines the payload format sent to the destination. Valid values are `slack`, `mattermost`, `googlechat`, and `discord`.",
 				Optional:    true,
 				ForceNew:    true,
 				ValidateFunc: validation.StringInSlice(
@@ -48,7 +48,7 @@ func resourceWebhook() *schema.Resource {
 			},
 			"subscriptions": {
 				Type:        schema.TypeSet,
-				Description: "The Tailscale events to subscribe this webhook to. See https://tailscale.com/kb/1213/webhooks#events for the list of valid events.",
+				Description: "The set of events that trigger this webhook. For a full list of event types, see the [webhooks documentation](https://tailscale.com/kb/1213/webhooks#events).",
 				Required:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
This patch adds a list of enum values to all resources and data sources, except webhooks, because it's such a long list.

Fixes https://github.com/tailscale/corp/issues/26867