### PR TITLE
posture_integration: add Fleet and Huntress providers

### DIFF
--- a/docs/resources/posture_integration.md
+++ b/docs/resources/posture_integration.md
@@ -27,7 +27,7 @@ resource "tailscale_posture_integration" "sample_posture_integration" {
 ### Required
 
 - `client_secret` (String, Sensitive) The secret (auth key, token, etc.) used to authenticate with the provider.
-- `posture_provider` (String) The third-party provider for posture data. Valid values are `falcon`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.
+- `posture_provider` (String) The third-party provider for posture data. Valid values are `falcon`, `fleet`, `huntress`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.
 
 ### Optional
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	golang.org/x/tools v0.40.0
 	tailscale.com v1.94.1
-	tailscale.com/client/tailscale/v2 v2.7.0
+	tailscale.com/client/tailscale/v2 v2.8.0
 )
 
 require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -301,5 +301,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 tailscale.com v1.94.1 h1:0dAst/ozTuFkgmxZULc3oNwR9+qPIt5ucvzH7kaM0Jw=
 tailscale.com v1.94.1/go.mod h1:gLnVrEOP32GWvroaAHHGhjSGMPJ1i4DvqNwEg+Yuov4=
-tailscale.com/client/tailscale/v2 v2.7.0 h1:yQzjpRsW12EkiGa9drakvmbcdNz2qsASUstxjJvois4=
-tailscale.com/client/tailscale/v2 v2.7.0/go.mod h1:FGjvGT3ThHelqo0gfdK3IN3k1dwNbRzYbQh2XO3C47U=
+tailscale.com/client/tailscale/v2 v2.8.0 h1:jU7jo7VyJAgi5besNeroZ0xkG7Exk56pJ18s+4nL7Pw=
+tailscale.com/client/tailscale/v2 v2.8.0/go.mod h1:FGjvGT3ThHelqo0gfdK3IN3k1dwNbRzYbQh2XO3C47U=

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -26,12 +26,14 @@ func resourcePostureIntegration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"posture_provider": {
 				Type:        schema.TypeString,
-				Description: "The third-party provider for posture data. Valid values are `falcon`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.",
+				Description: "The third-party provider for posture data. Valid values are `falcon`, `fleet`, `huntress`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.",
 				Required:    true,
 				ForceNew:    true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(tailscale.PostureIntegrationProviderFalcon),
+						string(tailscale.PostureIntegrationProviderFleet),
+						string(tailscale.PostureIntegrationProviderHuntress),
 						string(tailscale.PostureIntegrationProviderIntune),
 						string(tailscale.PostureIntegrationProviderJamfPro),
 						string(tailscale.PostureIntegrationProviderKandji),


### PR DESCRIPTION
**What this PR does / why we need it**: Allows customers to configure Fleet or Huntress as device posture providers using Terraform.

**Which issue this PR fixes**

Updates tailscale/corp#23481
Updates tailscale/corp#34555