### PR TITLE
all: create a Mux terraform for Terraform SDKv2 + plugin framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ the pull request it relates to.
 
 ## Making Changes
 
-To work in this repository, you will need go 1.17. You can use the standard go toolchain for building and testing your
+To work in this repository, you will need go 1.25. You can use the standard go toolchain for building and testing your
 changes. 
 
 If you want to enable acceptance tests, you *must* set the `TF_ACC` environment variable. 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,12 @@ require (
 	tailscale.com/client/tailscale/v2 v2.8.0
 )
 
-require github.com/pkg/errors v0.9.1
+require (
+	github.com/hashicorp/terraform-plugin-framework v1.18.0
+	github.com/hashicorp/terraform-plugin-go v0.30.0
+	github.com/hashicorp/terraform-plugin-mux v0.22.0
+	github.com/pkg/errors v0.9.1
+)
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
@@ -50,7 +55,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.0 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.30.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,14 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-docs v0.24.0 h1:YNZYd+8cpYclQyXbl1EEngbld8w7/LPOm99GD5nikIU=
 github.com/hashicorp/terraform-plugin-docs v0.24.0/go.mod h1:YLg+7LEwVmRuJc0EuCw0SPLxuQXw5mW8iJ5ml/kvi+o=
+github.com/hashicorp/terraform-plugin-framework v1.18.0 h1:Xy6OfqSTZfAAKXSlJ810lYvuQvYkOpSUoNMQ9l2L1RA=
+github.com/hashicorp/terraform-plugin-framework v1.18.0/go.mod h1:eeFIf68PME+kenJeqSrIcpHhYQK0TOyv7ocKdN4Z35E=
 github.com/hashicorp/terraform-plugin-go v0.30.0 h1:VmEiD0n/ewxbvV5VI/bYwNtlSEAXtHaZlSnyUUuQK6k=
 github.com/hashicorp/terraform-plugin-go v0.30.0/go.mod h1:8d523ORAW8OHgA9e8JKg0ezL3XUO84H0A25o4NY/jRo=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
+github.com/hashicorp/terraform-plugin-mux v0.22.0 h1:/NnqWVhbZlSRv1dAlLzqoAB0hLRTEUC+7vkz5RYE7co=
+github.com/hashicorp/terraform-plugin-mux v0.22.0/go.mod h1:+Atfnh0pgI4kUGQOQZopaFr7V86T/clYagjr9tuaFJo=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.39.0 h1:ltFG/dSs4mMHNpBqHptCtJqYM4FekUDJbUcWj+6HGlg=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.39.0/go.mod h1:xJk7ap8vRI/B2U6TrVs7bu/gTihyor8XBTLSs5Y6z2w=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=

--- a/main.go
+++ b/main.go
@@ -5,16 +5,46 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"context"
+	"flag"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 
 	"github.com/tailscale/terraform-provider-tailscale/tailscale"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: func() *schema.Provider {
-			return tailscale.Provider()
-		},
-	})
+	ctx := context.Background()
+
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	providers := []func() tfprotov5.ProviderServer{
+		providerserver.NewProtocol5(tailscale.NewFrameworkProvider()),
+		tailscale.Provider().GRPCProvider,
+	}
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var serveOpts []tf5server.ServeOpt
+
+	if debug {
+		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
+	}
+
+	err = tf5server.Serve(
+		"registry.terraform.io/tailscale/tailscale",
+		muxServer.ProviderServer,
+		serveOpts...,
+	)
 }

--- a/tailscale/data_source.go
+++ b/tailscale/data_source.go
@@ -1,0 +1,41 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"tailscale.com/client/tailscale/v2"
+)
+
+// DataSourceBase is a base struct for all Tailscale data sources.
+//
+// All data sources should extend this struct, then the authenticated [Client]
+// will be available in their [datasource.DataSource.Read] method.
+type DataSourceBase struct {
+	Client *tailscale.Client
+}
+
+// Configure attaches the client to the data source, so it can be used in the
+// [datasource.DataSource.Read] method.
+func (d *DataSourceBase) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*tailscale.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf(
+				"Expected *tailscale.Client, got: %T. Please report this error at https://github.com/tailscale/tailscale.",
+				req.ProviderData),
+		)
+		return
+	}
+
+	d.Client = client
+}

--- a/tailscale/data_source_4via6_test.go
+++ b/tailscale/data_source_4via6_test.go
@@ -30,9 +30,9 @@ data "tailscale_4via6" "invalid" {
 `
 
 func TestProvider_DataSourceTailscale4Via6(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:        true,
-		ProviderFactories: testProviderFactories(t),
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSource4Via6,
@@ -43,9 +43,9 @@ func TestProvider_DataSourceTailscale4Via6(t *testing.T) {
 }
 
 func TestProvider_DataSourceTailscale4Via6_InvalidSite(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:        true,
-		ProviderFactories: testProviderFactories(t),
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testDataSource4Via6InvalidSite,

--- a/tailscale/data_source_acl_test.go
+++ b/tailscale/data_source_acl_test.go
@@ -20,8 +20,8 @@ func TestAccTailscaleACL(t *testing.T) {
 	resourceName := "data.tailscale_acl.acl"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: `data "tailscale_acl" "acl" {}`,

--- a/tailscale/data_source_devices_test.go
+++ b/tailscale/data_source_devices_test.go
@@ -28,8 +28,8 @@ func TestAccTailscaleDevices(t *testing.T) {
 	// First test the tailscale_devices datasource, which will give us a list of
 	// all device IDs.
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: `data "tailscale_devices" "all_devices" {}`,
@@ -85,8 +85,8 @@ func TestAccTailscaleDevices(t *testing.T) {
 	// Now test the individual tailscale_device data sources for each device,
 	// making sure that it pulls in the relevant details for each device.
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: devicesDataSources.String(),
@@ -121,8 +121,8 @@ func TestAccTailscaleDevices(t *testing.T) {
 	// Test tailscale_devices with filters applied.
 	resourceNameFiltered := "data.tailscale_devices.filtered_devices"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: `data "tailscale_devices" "filtered_devices" { 

--- a/tailscale/data_source_users_test.go
+++ b/tailscale/data_source_users_test.go
@@ -24,8 +24,8 @@ func TestAccTailscaleUsers(t *testing.T) {
 	// First test the tailscale_users datasource, which will give us a list of
 	// all user IDs.
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: `data "tailscale_users" "all_users" {}`,
@@ -93,8 +93,8 @@ func TestAccTailscaleUsers(t *testing.T) {
 	// Now test the individual tailscale_user data sources for each user,
 	// making sure that it pulls in the relevant details for each user.
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: userDataSources.String(),

--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -1,0 +1,217 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+// Package tailscale describes the resources and data sources provided by the terraform provider. Each resource
+// or data source is described within its own file.
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"tailscale.com/client/tailscale/v2"
+)
+
+type tailscaleProvider struct {
+	Client tailscale.Client
+}
+
+// NewFrameworkProvider creates a new instance of the Terraform provider.
+//
+// TODO(alexc): This name is to distinguish it from the old provider written using
+// the plugin SDK. When we delete the plugin SDK code, we can rename this to NewProvider.
+func NewFrameworkProvider() provider.Provider {
+	return &tailscaleProvider{}
+}
+
+// Metadata defines information about the provider itself.
+func (p *tailscaleProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "tailscale"
+	resp.Version = providerVersion
+}
+
+// Schema defines a [schema.Schema] describing what data is available in the provider's
+// configuration.
+func (p *tailscaleProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"api_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "The API key to use for authenticating requests to the API. Can be set via the TAILSCALE_API_KEY environment variable. Conflicts with 'oauth_client_id' and 'oauth_client_secret'.",
+				Sensitive:   true,
+			},
+			"identity_token": schema.StringAttribute{
+				Optional:    true,
+				Description: "The jwt identity token to exchange for a Tailscale API token when using a federated identity. Can be set via the TAILSCALE_IDENTITY_TOKEN environment variable. Conflicts with 'api_key' and 'oauth_client_secret'.",
+				Sensitive:   true,
+			},
+			"oauth_client_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "The OAuth application or federated identity's ID when using OAuth client credentials or workload identity federation. Can be set via the TAILSCALE_OAUTH_CLIENT_ID environment variable. Either 'oauth_client_secret' or 'identity_token' must be set alongside 'oauth_client_id'. Conflicts with 'api_key'.",
+			},
+			"oauth_client_secret": schema.StringAttribute{
+				Optional:    true,
+				Description: "The OAuth application's secret when using OAuth client credentials. Can be set via the TAILSCALE_OAUTH_CLIENT_SECRET environment variable. Conflicts with 'api_key' and 'identity_token'.",
+				Sensitive:   true,
+			},
+			"scopes": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "The OAuth 2.0 scopes to request when generating the access token using the supplied OAuth client credentials. See https://tailscale.com/kb/1623/trust-credentials#scopes for available scopes. Only valid when both 'oauth_client_id' and 'oauth_client_secret', or both are set.",
+			},
+			"tailnet": schema.StringAttribute{
+				Optional:    true,
+				Description: "The tailnet ID. Tailnets created before Oct 2025 can still use the legacy ID, but the Tailnet ID is the preferred identifier. Can be set via the TAILSCALE_TAILNET environment variable. Default is the tailnet that owns API credentials passed to the provider.",
+			},
+			"base_url": schema.StringAttribute{
+				Optional:    true,
+				Description: "The base URL of the Tailscale API. Defaults to https://api.tailscale.com. Can be set via the TAILSCALE_BASE_URL environment variable.",
+			},
+			"user_agent": schema.StringAttribute{
+				Optional:    true,
+				Description: "User-Agent header for API requests.",
+			},
+		},
+	}
+}
+
+type tailscaleProviderModel struct {
+	APIKey            types.String `tfsdk:"api_key"`
+	IdentityToken     types.String `tfsdk:"identity_token"`
+	OAuthClientID     types.String `tfsdk:"oauth_client_id"`
+	OAuthClientSecret types.String `tfsdk:"oauth_client_secret"`
+	Tailnet           types.String `tfsdk:"tailnet"`
+	BaseURL           types.String `tfsdk:"base_url"`
+	UserAgent         types.String `tfsdk:"user_agent"`
+	Scopes            types.List   `tfsdk:"scopes"`
+}
+
+// Configure sets up the Tailscale client based on the provider-level data.
+func (p *tailscaleProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	var data tailscaleProviderModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	apiKey := coalesce(data.APIKey, os.Getenv("TAILSCALE_API_KEY"))
+	tailnet := coalesce(data.Tailnet, os.Getenv("TAILSCALE_TAILNET"), "-")
+	baseURL := coalesce(data.BaseURL, os.Getenv("TAILSCALE_BASE_URL"), "https://api.tailscale.com")
+
+	// Support both sets of OAuth Env vars for backwards compatibility
+	identityToken := coalesce(data.IdentityToken, os.Getenv("TAILSCALE_IDENTITY_TOKEN"), os.Getenv("IDENTITY_TOKEN"))
+	oauthClientID := coalesce(data.OAuthClientID, os.Getenv("TAILSCALE_OAUTH_CLIENT_ID"), os.Getenv("OAUTH_CLIENT_ID"))
+	oauthClientSecret := coalesce(data.OAuthClientSecret, os.Getenv("TAILSCALE_OAUTH_CLIENT_SECRET"), os.Getenv("OAUTH_CLIENT_SECRET"))
+
+	var userAgent string
+	if data.UserAgent.ValueString() != "" {
+		userAgent = data.UserAgent.ValueString()
+	} else {
+		userAgent = fmt.Sprintf(
+			"Terraform/%s (+https://www.terraform.io) terraform-provider-tailscale/%s",
+			req.TerraformVersion,
+			providerVersion)
+	}
+
+	var scopes []string
+	resp.Diagnostics.Append(data.Scopes.ElementsAs(ctx, &scopes, false)...)
+
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Could not parse base URL",
+			fmt.Sprintf("While configuring the provider, "+
+				"the base URL %q could not be parsed: %v", baseURL, err),
+		)
+	}
+
+	if tailnet == "" {
+		resp.Diagnostics.AddError(
+			"Missing Tailnet ID",
+			"While configuring the provider, a Tailnet ID was not found in the "+
+				"TAILSCALE_TAILNET environment variable or provider configuration block "+
+				"tailnet attribute.",
+		)
+	}
+
+	if err := validateProviderCreds(apiKey, oauthClientID, oauthClientID, identityToken); err != nil {
+		resp.Diagnostics.AddError("Provider credentials error", err[0].Summary)
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	p.Client = createTailscaleClient(parsedBaseURL, userAgent, tailnet, apiKey, oauthClientID, oauthClientSecret, identityToken, scopes)
+
+	// Make the Tailscale client available during DataSource and Resource
+	// type Configure methods.
+	resp.ResourceData = &p.Client
+	resp.DataSourceData = &p.Client
+}
+
+// Resources returns a slice of resources.
+func (p *tailscaleProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+// DataSources returns a slice of data sources.
+func (p *tailscaleProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}
+
+// coalesce chooses a string value in order of decreasing priority.
+//
+// It returns the first value which is non-empty -- either configuration data, or
+// the first non-empty fallback value.
+func coalesce(val types.String, fallbacks ...string) string {
+	if !val.IsNull() && !val.IsUnknown() {
+		return val.ValueString()
+	}
+	for _, f := range fallbacks {
+		if f != "" {
+			return f
+		}
+	}
+	return ""
+}
+
+// createTailscaleClient creates a new Tailscale API client based on the credentials
+// provided to the Terraform provider.
+func createTailscaleClient(baseURL *url.URL, userAgent string, tailnet string, apiKey string, oauthClientID string, oauthClientSecret string, identityToken string, scopes []string) tailscale.Client {
+	if oauthClientID != "" && oauthClientSecret != "" {
+		return tailscale.Client{
+			BaseURL:   baseURL,
+			UserAgent: userAgent,
+			Tailnet:   tailnet,
+			Auth: &tailscale.OAuth{
+				ClientID:     oauthClientID,
+				ClientSecret: oauthClientSecret,
+				Scopes:       scopes,
+			},
+		}
+	} else if oauthClientID != "" && identityToken != "" {
+		return tailscale.Client{
+			BaseURL:   baseURL,
+			UserAgent: userAgent,
+			Tailnet:   tailnet,
+			Auth: &tailscale.IdentityFederation{
+				ClientID: oauthClientID,
+				IDTokenFunc: func() (string, error) {
+					return identityToken, nil
+				},
+			},
+		}
+	} else {
+		return tailscale.Client{
+			BaseURL:   baseURL,
+			UserAgent: userAgent,
+			APIKey:    apiKey,
+			Tailnet:   tailnet,
+		}
+	}
+}

--- a/tailscale/provider_sdk.go
+++ b/tailscale/provider_sdk.go
@@ -27,7 +27,12 @@ var providerVersion = "dev"
 
 type ProviderOption func(p *schema.Provider)
 
-// Provider returns the *schema.Provider instance that implements the terraform provider.
+// Provider returns the [schema.Provider] instance that implements the terraform provider.
+//
+// This implements the SDKv2 version of the Terraform provider, and will gradually be
+// removed and eventually deleted as we migrate to the plugin framework.
+//
+// Remove this when we close https://github.com/tailscale/corp/issues/37032
 func Provider(options ...ProviderOption) *schema.Provider {
 	// Support both sets of OAuth Env vars for backwards compatibility
 	oauthClientIDEnvVars := []string{"TAILSCALE_OAUTH_CLIENT_ID", "OAUTH_CLIENT_ID"}
@@ -155,52 +160,19 @@ func providerConfigure(_ context.Context, provider *schema.Provider, d *schema.R
 		userAgent = provider.UserAgent("terraform-provider-tailscale", providerVersion)
 	}
 
+	var scopes []string
 	if oauthClientID != "" && oauthClientSecret != "" {
-		var oauthScopes []string
 		oauthScopesFromConfig := d.Get("scopes").([]interface{})
 		if len(oauthScopesFromConfig) > 0 {
-			oauthScopes = make([]string, len(oauthScopesFromConfig))
+			scopes = make([]string, len(oauthScopesFromConfig))
 		}
 		for i, scope := range oauthScopesFromConfig {
-			oauthScopes[i] = scope.(string)
+			scopes[i] = scope.(string)
 		}
-
-		client := &tailscale.Client{
-			BaseURL:   parsedBaseURL,
-			UserAgent: userAgent,
-			Tailnet:   tailnet,
-			Auth: &tailscale.OAuth{
-				ClientID:     oauthClientID,
-				ClientSecret: oauthClientSecret,
-				Scopes:       oauthScopes,
-			},
-		}
-
-		return client, nil
 	}
 
-	if oauthClientID != "" && idToken != "" {
-		return &tailscale.Client{
-			BaseURL:   parsedBaseURL,
-			UserAgent: userAgent,
-			Tailnet:   tailnet,
-			Auth: &tailscale.IdentityFederation{
-				ClientID: oauthClientID,
-				IDTokenFunc: func() (string, error) {
-					return idToken, nil
-				},
-			},
-		}, nil
-	}
-
-	client := &tailscale.Client{
-		BaseURL:   parsedBaseURL,
-		UserAgent: userAgent,
-		APIKey:    apiKey,
-		Tailnet:   tailnet,
-	}
-
-	return client, nil
+	client := createTailscaleClient(parsedBaseURL, userAgent, tailnet, apiKey, oauthClientID, oauthClientSecret, idToken, scopes)
+	return &client, nil
 }
 
 func validateProviderCreds(apiKey string, oauthClientID string, oauthClientSecret string, idToken string) diag.Diagnostics {

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -12,6 +12,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -51,12 +55,29 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccProviderFactories(t *testing.T) map[string]func() (*schema.Provider, error) {
+// testAccProviderFactories creates a mux server that serves both the SDKv2 and
+// the plugin framework providers.
+//
+// See https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux#protocol-version-5
+func testAccProviderFactories(t *testing.T) map[string]func() (tfprotov5.ProviderServer, error) {
 	t.Helper()
 
-	return map[string]func() (*schema.Provider, error){
-		"tailscale": func() (*schema.Provider, error) {
-			return Provider(), nil
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		"tailscale": func() (tfprotov5.ProviderServer, error) {
+			ctx := context.Background()
+
+			providers := []func() tfprotov5.ProviderServer{
+				providerserver.NewProtocol5(NewFrameworkProvider()),
+				Provider().GRPCProvider,
+			}
+
+			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return muxServer.ProviderServer(), nil
 		},
 	}
 }
@@ -69,23 +90,40 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_Implemented(t *testing.T) {
 	var _ *schema.Provider = Provider()
+	var _ provider.Provider = NewFrameworkProvider()
 }
 
-func testProviderFactories(t *testing.T) map[string]func() (*schema.Provider, error) {
+// testProviderFactories creates a mux server that serves both the SDKv2 and
+// the plugin framework providers.
+//
+// See https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux#protocol-version-5
+func testProviderFactories(t *testing.T) map[string]func() (tfprotov5.ProviderServer, error) {
 	t.Helper()
 
 	testClient, testServer = NewTestHarness(t)
-	return map[string]func() (*schema.Provider, error){
-		"tailscale": func() (*schema.Provider, error) {
-			return Provider(func(p *schema.Provider) {
-				// Set up a test harness for the provider
-				p.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
-					return testClient, nil
-				}
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		"tailscale": func() (tfprotov5.ProviderServer, error) {
+			ctx := context.Background()
 
-				// Don't require any of the global configuration
-				p.Schema = nil
-			}), nil
+			t.Setenv("TAILSCALE_API_KEY", "api_123")
+
+			providers := []func() tfprotov5.ProviderServer{
+				providerserver.NewProtocol5(NewFrameworkProvider()),
+				Provider(func(p *schema.Provider) {
+					// Set up a test harness for the provider
+					p.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+						return testClient, nil
+					}
+				}).GRPCProvider,
+			}
+
+			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return muxServer.ProviderServer(), nil
 		},
 	}
 }

--- a/tailscale/resource.go
+++ b/tailscale/resource.go
@@ -1,0 +1,41 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"tailscale.com/client/tailscale/v2"
+)
+
+// ResourceBase is a base struct for all Tailscale resources.
+//
+// All resources should extend this struct, then the authenticated [Client] will
+// be available in their CRUD methods.
+type ResourceBase struct {
+	Client *tailscale.Client
+}
+
+// Configure attaches the client to the resource, so it can be used in the
+// CRUD methods.
+func (d *ResourceBase) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*tailscale.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf(
+				"Expected *tailscale.Client, got: %T. Please report this error at https://github.com/tailscale/tailscale.",
+				req.ProviderData),
+		)
+		return
+	}
+
+	d.Client = client
+}

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -82,7 +82,7 @@ func TestProvider_TailscaleACL(t *testing.T) {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = nil
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_acl.test_acl", testACL),
 			testResourceDestroyed("tailscale_acl.test_acl", testACL),
@@ -115,8 +115,8 @@ func TestProvider_TailscaleACLDiffs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		IsUnitTest:        true,
-		ProviderFactories: testProviderFactories(t),
+		IsUnitTest:               true,
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		PreCheck: func() {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = []byte("{}")
@@ -183,8 +183,8 @@ func TestAccACL(t *testing.T) {
 		}`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testACLCreate,
@@ -246,8 +246,8 @@ func TestAccACL_resetOnDestroy(t *testing.T) {
 		}`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		CheckDestroy: checkResourceDestroyed(resourceName, func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			aclAfterDestroy, err := client.PolicyFile().Raw(context.Background())
 			if err != nil {

--- a/tailscale/resource_aws_external_id_test.go
+++ b/tailscale/resource_aws_external_id_test.go
@@ -17,8 +17,8 @@ func TestAccTailscaleAWSExternalID(t *testing.T) {
 	const resourceName = "tailscale_aws_external_id.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAWSExternalID,

--- a/tailscale/resource_contacts_test.go
+++ b/tailscale/resource_contacts_test.go
@@ -95,8 +95,8 @@ func TestAccTailscaleContacts(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// Contacts are not destroyed in the control plane upon resource deletion since
 		// contacts cannot be empty, so make sure that contacts are still the updated contacts.
 		CheckDestroy: checkResourceDestroyed(resourceName, checkProperties(expectedContactsUpdated)),

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -57,8 +57,8 @@ func TestAccTailscaleDeviceAuthorization(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// Devices are not currently deauthorized when this resource is deleted,
 		// expect that the device both exists and is still authorized.
 		CheckDestroy: checkResourceDestroyed(resourceName, checkAuthorized),
@@ -122,8 +122,8 @@ func TestAccTailscaleDeviceAuthorization_UsesNodeID(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// Devices are not currently deauthorized when this resource is deleted,
 		// expect that the device both exists and is still authorized.
 		CheckDestroy: checkResourceDestroyed(resourceName, checkAuthorized),

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -71,8 +71,8 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// After delete, device key should revert to its default properties
 		// This is probably not how we actually want things to work, but it's the released behavior.
 		// See https://github.com/tailscale/terraform-provider-tailscale/issues/401.
@@ -157,8 +157,8 @@ func TestAccTailscaleDeviceKey_UsesNodeID(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// After delete, device key should revert to its default properties
 		// This is probably not how we actually want things to work, but it's the released behavior.
 		// See https://github.com/tailscale/terraform-provider-tailscale/issues/401.

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -65,9 +65,9 @@ func TestAccTailscaleDeviceSubnetRoutes(t *testing.T) {
 
 	var deviceId string
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties([]string{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties([]string{})),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testDeviceSubnetRoutesCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
@@ -212,9 +212,9 @@ func TestAccTailscaleDeviceSubnetRoutes_WithNodeID(t *testing.T) {
 
 	var deviceId string
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties([]string{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties([]string{})),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testDeviceSubnetRoutesCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
@@ -374,9 +374,9 @@ func TestAccTailscaleDeviceSubnetRoutes_LegacyIDToNodeID(t *testing.T) {
 
 	var deviceId string
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties([]string{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties([]string{})),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testDeviceSubnetRoutesCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -78,8 +78,8 @@ func TestAccTailscaleDeviceTags(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
@@ -184,8 +184,8 @@ func TestAccTailscaleDeviceTags_UsesNodeID(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/tailscale/resource_dns_configuration_test.go
+++ b/tailscale/resource_dns_configuration_test.go
@@ -69,7 +69,7 @@ func TestProvider_TailscaleDNSConfiguration(t *testing.T) {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = nil
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_configuration.test_configuration", testDNSConfigurationCreate),
 			testResourceDestroyed("tailscale_dns_configuration.test_configuration", testDNSConfigurationCreate),
@@ -96,9 +96,9 @@ func TestAccTailscaleDNSConfiguration(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties(&tailscale.DNSConfiguration{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties(&tailscale.DNSConfiguration{})),
 		Steps: []resource.TestStep{
 			{
 				Config: testDNSConfigurationCreate,

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -36,7 +36,7 @@ func TestProvider_TailscaleDNSNameservers(t *testing.T) {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = nil
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_nameservers.test_nameservers", testNameserversCreate),
 			testResourceDestroyed("tailscale_dns_nameservers.test_nameservers", testNameserversCreate),
@@ -63,9 +63,9 @@ func TestAccTailscaleDNSNameservers(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties([]string{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties([]string{})),
 		Steps: []resource.TestStep{
 			{
 				Config: testNameserversCreate,

--- a/tailscale/resource_dns_preferences_test.go
+++ b/tailscale/resource_dns_preferences_test.go
@@ -31,7 +31,7 @@ func TestProvider_TailscaleDNSPreferences(t *testing.T) {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = nil
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_preferences.test_preferences", testDNSPreferencesCreate),
 			testResourceDestroyed("tailscale_dns_preferences.test_preferences", testDNSPreferencesCreate),
@@ -58,9 +58,9 @@ func TestAccTailscaleDNSPreferences(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties(&tailscale.DNSPreferences{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties(&tailscale.DNSPreferences{})),
 		Steps: []resource.TestStep{
 			{
 				Config: testDNSPreferencesCreate,

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -36,7 +36,7 @@ func TestProvider_TailscaleDNSSearchPaths(t *testing.T) {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = nil
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_search_paths.test_search_paths", testSearchPathsCreate),
 			testResourceDestroyed("tailscale_dns_search_paths.test_search_paths", testSearchPathsCreate),
@@ -63,9 +63,9 @@ func TestAccTailscaleDNSSearchPaths(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties([]string{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties([]string{})),
 		Steps: []resource.TestStep{
 			{
 				Config: testSearchPathsCreate,

--- a/tailscale/resource_dns_split_nameservers_test.go
+++ b/tailscale/resource_dns_split_nameservers_test.go
@@ -29,7 +29,7 @@ func TestProvider_TailscaleSplitDNSNameservers(t *testing.T) {
 			testServer.ResponseCode = http.StatusOK
 			testServer.ResponseBody = nil
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_split_nameservers.test_nameservers", testSplitNameservers),
 			testResourceDestroyed("tailscale_dns_split_nameservers.test_nameservers", testSplitNameservers),
@@ -74,9 +74,9 @@ func TestAccTailscaleDNSSplitNameservers(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkProperties(tailscale.SplitDNSResponse{})),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkProperties(tailscale.SplitDNSResponse{})),
 		Steps: []resource.TestStep{
 			{
 				Config: testSplitNameserversCreate,

--- a/tailscale/resource_federated_identity_test.go
+++ b/tailscale/resource_federated_identity_test.go
@@ -44,7 +44,7 @@ func TestProvider_TailscaleFederatedIdentity(t *testing.T) {
 				},
 			}
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_federated_identity.example_federated_identity", testFederatedIdentity),
 			testResourceDestroyed("tailscale_federated_identity.example_federated_identity", testFederatedIdentity),
@@ -139,9 +139,9 @@ func TestAccTailscaleFederatedIdentity(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkFederatedIdentityDeleted),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkFederatedIdentityDeleted),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/tailscale/resource_logstream_configuration_test.go
+++ b/tailscale/resource_logstream_configuration_test.go
@@ -188,8 +188,8 @@ func TestAccTailscaleLogstreamConfiguration(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		CheckDestroy: checkResourceDestroyed(resourceName, func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			_, err := client.Logging().LogstreamConfiguration(context.Background(), tailscale.LogType(rs.Primary.ID))
 			if err == nil {

--- a/tailscale/resource_oauth_client_test.go
+++ b/tailscale/resource_oauth_client_test.go
@@ -33,7 +33,7 @@ func TestProvider_TailscaleOAuthClient(t *testing.T) {
 				Key: "thisisatestclient",
 			}
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_oauth_client.example_oauth_client", testOAuthClient),
 			testResourceDestroyed("tailscale_oauth_client.example_oauth_client", testOAuthClient),
@@ -111,9 +111,9 @@ func TestAccTailscaleOAuthClient(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
-		CheckDestroy:      checkResourceDestroyed(resourceName, checkOAuthClientDeleted),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy:             checkResourceDestroyed(resourceName, checkOAuthClientDeleted),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/tailscale/resource_posture_integration_test.go
+++ b/tailscale/resource_posture_integration_test.go
@@ -67,8 +67,8 @@ func TestAccTailscalePostureIntegration(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		CheckDestroy: checkResourceDestroyed(resourceName, func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			_, err := client.DevicePosture().GetIntegration(context.Background(), rs.Primary.ID)
 			if err == nil {

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -40,7 +40,7 @@ func TestProvider_TailscaleTailnetKey(t *testing.T) {
 				Key:     "thisisatestkey",
 			}
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_tailnet_key.example_key", testTailnetKey),
 			testResourceDestroyed("tailscale_tailnet_key.example_key", testTailnetKey),
@@ -142,7 +142,7 @@ func TestProvider_TailscaleTailnetKeyInvalid(t *testing.T) {
 				Key:     "thisisatestkey",
 			}
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			// Create a reusable key.
 			setKeyStep(true, ""),
@@ -246,8 +246,8 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 	expectedKeyUpdated.Capabilities.Devices.Create.Tags = []string{"tag:b"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/tailscale/resource_tailnet_settings_test.go
+++ b/tailscale/resource_tailnet_settings_test.go
@@ -62,8 +62,8 @@ func TestAccTailscaleTailnetSettings(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testTailnetSettingsCreate,

--- a/tailscale/resource_webhook_test.go
+++ b/tailscale/resource_webhook_test.go
@@ -40,7 +40,7 @@ func TestProvider_TailscaleWebhook(t *testing.T) {
 				EndpointID: "12345",
 			}
 		},
-		ProviderFactories: testProviderFactories(t),
+		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_webhook.test_webhook", testWebhook),
 			testResourceDestroyed("tailscale_webhook.test_webhook", testWebhook),
@@ -76,8 +76,8 @@ func TestAccTailscaleWebhook(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		CheckDestroy: checkResourceDestroyed(resourceName, func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			_, err := client.Webhooks().Get(context.Background(), rs.Primary.ID)
 			if err == nil {


### PR DESCRIPTION
Start migrating to the Terraform plugin framework by [serving the provider][1] using both the existing SDKv2 and the framework served via [a mux][2]. This patch contains the basic mux server and enough changes to get the acceptance tests passing, but doesn't actually implement any resources or data sources.

[1]: https://developer.hashicorp.com/terraform/plugin/framework/migrating/providers#serving-the-provider
[2]: https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux

Updates tailscale/corp#37220