### PR TITLE
resource_device_key: migrate to plugin framework

### DIFF
--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -158,6 +158,7 @@ func (p *tailscaleProvider) Configure(ctx context.Context, req provider.Configur
 func (p *tailscaleProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewAWSExternalIDResource,
+		NewDeviceKeyResource,
 	}
 }
 

--- a/tailscale/provider_sdk.go
+++ b/tailscale/provider_sdk.go
@@ -103,7 +103,6 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"tailscale_device_authorization":    resourceDeviceAuthorization(),
 			"tailscale_tailnet_key":             resourceTailnetKey(),
 			"tailscale_device_tags":             resourceDeviceTags(),
-			"tailscale_device_key":              resourceDeviceKey(),
 			"tailscale_oauth_client":            resourceOAuthClient(),
 			"tailscale_webhook":                 resourceWebhook(),
 			"tailscale_contacts":                resourceContacts(),

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -6,30 +6,49 @@ package tailscale
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"tailscale.com/client/tailscale/v2"
 )
 
-func resourceDeviceKey() *schema.Resource {
-	return &schema.Resource{
-		Description:   "The device_key resource allows you to update the properties of a device's key",
-		ReadContext:   resourceDeviceKeyRead,
-		CreateContext: resourceDeviceKeyCreate,
-		DeleteContext: resourceDeviceKeyDelete,
-		UpdateContext: resourceDeviceKeyUpdate,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"device_id": {
-				Type:        schema.TypeString,
+type deviceKeyResourceModel struct {
+	ID                types.String `tfsdk:"id"`
+	DeviceID          types.String `tfsdk:"device_id"`
+	KeyExpiryDisabled types.Bool   `tfsdk:"key_expiry_disabled"`
+}
+
+// NewDeviceKeyResource returns a new device key resource.
+func NewDeviceKeyResource() resource.Resource {
+	return &deviceKeyResource{}
+}
+
+type deviceKeyResource struct {
+	ResourceBase
+}
+
+func (d deviceKeyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_device_key"
+}
+
+func (d deviceKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "The device_key resource allows you to update the properties of a device's key",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"device_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The device to update the key properties of",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"key_expiry_disabled": {
-				Type:        schema.TypeBool,
+			"key_expiry_disabled": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Determines whether or not the device's key will expire. Defaults to `false`.",
 			},
@@ -37,44 +56,71 @@ func resourceDeviceKey() *schema.Resource {
 	}
 }
 
-func resourceDeviceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+func (d deviceKeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan deviceKeyResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	deviceID := d.Get("device_id").(string)
-	keyExpiryDisabled := d.Get("key_expiry_disabled").(bool)
+	deviceID := plan.DeviceID.ValueString()
+	keyExpiryDisabled := plan.KeyExpiryDisabled.ValueBool()
 
 	key := tailscale.DeviceKey{
 		KeyExpiryDisabled: keyExpiryDisabled,
 	}
 
-	if err := client.Devices().SetKey(ctx, deviceID, key); err != nil {
-		return diagnosticsError(err, "failed to update device key")
+	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to create device key",
+			"Could not create device key: "+err.Error(),
+		)
+		return
 	}
 
-	d.SetId(deviceID)
-	return resourceDeviceKeyRead(ctx, d, m)
+	plan.ID = types.StringValue(deviceID)
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
 }
 
-func resourceDeviceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+func (d deviceKeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state deviceKeyResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	deviceID := d.Get("device_id").(string)
+	deviceID := state.DeviceID.ValueString()
 	key := tailscale.DeviceKey{}
 
-	if err := client.Devices().SetKey(ctx, deviceID, key); err != nil {
-		return diagnosticsError(err, "failed to update device key")
+	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to delete device key",
+			"Could not delete device key: "+err.Error(),
+		)
+		return
 	}
-
-	return nil
 }
 
-func resourceDeviceKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
-	deviceID := d.Id()
+func (d deviceKeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state deviceKeyResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	device, err := client.Devices().Get(ctx, deviceID)
+	deviceID := state.ID.ValueString()
+
+	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
-		return diagnosticsError(err, "Failed to fetch devices")
+		resp.Diagnostics.AddError(
+			"Failed to fetch devices",
+			"Could not read device key for device with ID "+deviceID+": "+err.Error(),
+		)
+		return
 	}
 
 	// If the device lookup succeeds and the state ID is not the same as the legacy ID, we can assume the ID is the node ID.
@@ -83,29 +129,41 @@ func resourceDeviceKeyRead(ctx context.Context, d *schema.ResourceData, m interf
 		canonicalDeviceID = device.NodeID
 	}
 
-	if err = d.Set("device_id", canonicalDeviceID); err != nil {
-		return diagnosticsError(err, "failed to set device_id")
-	}
-	if err = d.Set("key_expiry_disabled", device.KeyExpiryDisabled); err != nil {
-		return diagnosticsError(err, "failed to set key_expiry_disabled field")
-	}
+	state.DeviceID = types.StringValue(canonicalDeviceID)
+	state.KeyExpiryDisabled = types.BoolValue(device.KeyExpiryDisabled)
 
-	return nil
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
-func resourceDeviceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+func (d deviceKeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan deviceKeyResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	deviceID := d.Get("device_id").(string)
-	keyExpiryDisabled := d.Get("key_expiry_disabled").(bool)
+	deviceID := plan.DeviceID.ValueString()
+	keyExpiryDisabled := plan.KeyExpiryDisabled.ValueBool()
 
 	key := tailscale.DeviceKey{
 		KeyExpiryDisabled: keyExpiryDisabled,
 	}
 
-	if err := client.Devices().SetKey(ctx, deviceID, key); err != nil {
-		return diagnosticsError(err, "failed to update device key")
+	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to update device key",
+			"Could not update device key: "+err.Error(),
+		)
+		return
 	}
 
-	return resourceDeviceKeyRead(ctx, d, m)
+	plan.ID = types.StringValue(deviceID)
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (d deviceKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -101,6 +101,25 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 			},
 		},
 	})
+
+	// Migration test to ensure the resource is unchanged when migrating
+	// from the plugin SDK to the plugin framework.
+	//
+	// See https://developer.hashicorp.com/terraform/plugin/framework/migrating/testing#terraform-data-resource-example
+	checkResourceIsUnchangedInPluginFramework(t,
+		fmt.Sprintf(testDeviceKeyCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName, checkProperties(false)),
+			checkResourceRemoteProperties(resourceName, checkLegacyID),
+			resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "false"),
+		))
+	checkResourceIsUnchangedInPluginFramework(t,
+		fmt.Sprintf(testDeviceKeyUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName, checkProperties(true)),
+			checkResourceRemoteProperties(resourceName, checkLegacyID),
+			resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "true"),
+		))
 }
 func TestAccTailscaleDeviceKey_UsesNodeID(t *testing.T) {
 	const resourceName = "tailscale_device_key.test_key"
@@ -187,4 +206,23 @@ func TestAccTailscaleDeviceKey_UsesNodeID(t *testing.T) {
 			},
 		},
 	})
+
+	// Migration test to ensure the resource is unchanged when migrating
+	// from the plugin SDK to the plugin framework.
+	//
+	// See https://developer.hashicorp.com/terraform/plugin/framework/migrating/testing#terraform-data-resource-example
+	checkResourceIsUnchangedInPluginFramework(t,
+		fmt.Sprintf(testDeviceKeyCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName, checkProperties(false)),
+			checkResourceRemoteProperties(resourceName, checkNodeID),
+			resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "false"),
+		))
+	checkResourceIsUnchangedInPluginFramework(t,
+		fmt.Sprintf(testDeviceKeyUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName, checkProperties(true)),
+			checkResourceRemoteProperties(resourceName, checkNodeID),
+			resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "true"),
+		))
 }


### PR DESCRIPTION
This migrates the device key resource to the plugin framework.

This also introduces a RequiresReplace plan modifier to the device ID attribute. The device key's resource ID currently tracks the device ID. 

Previously it was possible for to change the device ID in a config to point to a different device, but the underlying resource ID would keep pointing to the original device, which can quickly result in situations with inconsistent state. 

For example, I could apply a device key resource, then update the device_id. Whenever I now re-apply, the plan will show the device_id changing to the new device ID but the device that gets changed is the device with the original device ID. 

Introducing RequiresReplace for the device ID was the most economic way to resolve this.

Terraform acceptance test run: https://github.com/tailscale/corp/actions/runs/23747478031/job/69179916438

Fixes tailscale/corp#37232


