### PR TITLE
resource_device_authorization: preserve state ID on update

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -48,6 +48,9 @@ func (d deviceAuthorizationResource) Schema(_ context.Context, _ resource.Schema
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"device_id": schema.StringAttribute{
 				Required:    true,
@@ -106,13 +109,11 @@ func (d deviceAuthorizationResource) Create(ctx context.Context, req resource.Cr
 	deviceID := plan.DeviceID.ValueString()
 	authorized := plan.Authorized.ValueBool()
 
-	if authorized {
-		if err := d.Client.Devices().SetAuthorized(ctx, deviceID, true); err != nil {
-			resp.Diagnostics.AddError(
-				"Failed to authorize device",
-				"Could not authorize device with ID "+deviceID+": "+err.Error(),
-			)
-		}
+	if err := d.Client.Devices().SetAuthorized(ctx, deviceID, authorized); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to authorize device",
+			"Could not authorize device with ID "+deviceID+": "+err.Error(),
+		)
 	}
 
 	plan.ID = types.StringValue(deviceID)
@@ -130,30 +131,15 @@ func (d deviceAuthorizationResource) Update(ctx context.Context, req resource.Up
 
 	deviceID := plan.DeviceID.ValueString()
 
-	device, err := d.Client.Devices().Get(ctx, deviceID)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to fetch device",
-			"Could not fetch device with device with ID"+deviceID+": "+err.Error(),
-		)
-		return
-	}
+	authorized := plan.Authorized.ValueBool()
 
-	// Currently, the Tailscale API only supports authorizing a device, but not un-authorizing one. So if the device
-	// data from the API states it is authorized then we can't do anything else here.
-	if device.Authorized {
-		plan.Authorized = types.BoolValue(true)
-		return
-	}
-
-	if err = d.Client.Devices().SetAuthorized(ctx, deviceID, true); err != nil {
+	if err := d.Client.Devices().SetAuthorized(ctx, deviceID, authorized); err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to authorize device",
 			"Could not authorize device with ID"+deviceID+": "+err.Error(),
 		)
 		return
 	}
-	plan.Authorized = types.BoolValue(true)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -162,4 +148,15 @@ func (d deviceAuthorizationResource) Update(ctx context.Context, req resource.Up
 func (d deviceAuthorizationResource) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
 	// Since authorization cannot be removed at this point, deleting the resource will do nothing.
 	return
+}
+
+func (r deviceAuthorizationResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// If the entire plan is null, the resource is planned for destruction.
+	if req.Plan.Raw.IsNull() {
+		resp.Diagnostics.AddWarning(
+			"Resource Destruction Considerations",
+			"Applying this resource destruction will only remove the resource from the Terraform state and "+
+				"will not modify the device's authorization. ",
+		)
+	}
 }

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -18,7 +18,7 @@ import (
 func TestAccTailscaleDeviceAuthorization(t *testing.T) {
 	const resourceName = "tailscale_device_authorization.test_authorization"
 
-	const testDeviceAuthorization = `
+	const testDeviceAuthorizationCreate = `
 		data "tailscale_device" "test_device" {
 			name = "%s"
 		}
@@ -28,18 +28,39 @@ func TestAccTailscaleDeviceAuthorization(t *testing.T) {
 			authorized = true
 		}`
 
-	checkAuthorized := func(client *tailscale.Client, rs *terraform.ResourceState) error {
-		// Check that the device both exists and is still authorized.
-		device, err := client.Devices().Get(context.Background(), rs.Primary.ID)
-		if err != nil {
-			return err
+	const testDeviceAuthorizationUpdate = `
+		data "tailscale_device" "test_device" {
+			name = "%s"
 		}
+		
+		resource "tailscale_device_authorization" "test_authorization" {
+			device_id = data.tailscale_device.test_device.id
+			authorized = false
+		}`
 
-		if device.Authorized != true {
-			return fmt.Errorf("device with id %q is not authorized", rs.Primary.ID)
+	const testDeviceAuthorizationNextUpdate = `
+		data "tailscale_device" "test_device" {
+			name = "%s"
 		}
+		
+		resource "tailscale_device_authorization" "test_authorization" {
+			device_id = data.tailscale_device.test_device.id
+			authorized = true
+		}`
 
-		return nil
+	checkAuthorized := func(wantAuthorized bool) func(client *tailscale.Client, rs *terraform.ResourceState) error {
+		return func(client *tailscale.Client, rs *terraform.ResourceState) error {
+			device, err := client.Devices().Get(context.Background(), rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			if device.Authorized != wantAuthorized {
+				return fmt.Errorf("device with id %q is not authorized", rs.Primary.ID)
+			}
+
+			return nil
+		}
 	}
 
 	checkLegacyID := func(client *tailscale.Client, rs *terraform.ResourceState) error {
@@ -60,14 +81,31 @@ func TestAccTailscaleDeviceAuthorization(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// Devices are not currently deauthorized when this resource is deleted,
+		// so if the resource is authorized when the resource gets deleted,
 		// expect that the device both exists and is still authorized.
-		CheckDestroy: checkResourceDestroyed(resourceName, checkAuthorized),
+		CheckDestroy: checkResourceDestroyed(resourceName, checkAuthorized(true)),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testDeviceAuthorization, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Config: fmt.Sprintf(testDeviceAuthorizationCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceRemoteProperties(resourceName, checkLegacyID),
-					checkResourceRemoteProperties(resourceName, checkAuthorized),
+					checkResourceRemoteProperties(resourceName, checkAuthorized(true)),
+					resource.TestCheckResourceAttr(resourceName, "authorized", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testDeviceAuthorizationUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkLegacyID),
+					checkResourceRemoteProperties(resourceName, checkAuthorized(false)),
+					resource.TestCheckResourceAttr(resourceName, "authorized", "false"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testDeviceAuthorizationNextUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkLegacyID),
+					checkResourceRemoteProperties(resourceName, checkAuthorized(true)),
 					resource.TestCheckResourceAttr(resourceName, "authorized", "true"),
 				),
 			},
@@ -80,10 +118,10 @@ func TestAccTailscaleDeviceAuthorization(t *testing.T) {
 	})
 
 	checkResourceIsUnchangedInPluginFramework(t,
-		fmt.Sprintf(testDeviceAuthorization, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+		fmt.Sprintf(testDeviceAuthorizationCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
 		resource.ComposeTestCheckFunc(
 			checkResourceRemoteProperties(resourceName, checkLegacyID),
-			checkResourceRemoteProperties(resourceName, checkAuthorized),
+			checkResourceRemoteProperties(resourceName, checkAuthorized(true)),
 			resource.TestCheckResourceAttr(resourceName, "authorized", "true"),
 		),
 	)
@@ -92,7 +130,7 @@ func TestAccTailscaleDeviceAuthorization(t *testing.T) {
 func TestAccTailscaleDeviceAuthorization_UsesNodeID(t *testing.T) {
 	const resourceName = "tailscale_device_authorization.test_authorization"
 
-	const testDeviceAuthorization = `
+	const testDeviceAuthorizationCreate = `
 		data "tailscale_device" "test_device" {
 			name = "%s"
 		}
@@ -102,18 +140,39 @@ func TestAccTailscaleDeviceAuthorization_UsesNodeID(t *testing.T) {
 			authorized = true
 		}`
 
-	checkAuthorized := func(client *tailscale.Client, rs *terraform.ResourceState) error {
-		// Check that the device both exists and is still authorized.
-		device, err := client.Devices().Get(context.Background(), rs.Primary.ID)
-		if err != nil {
-			return err
+	const testDeviceAuthorizationUpdate = `
+		data "tailscale_device" "test_device" {
+			name = "%s"
 		}
+		
+		resource "tailscale_device_authorization" "test_authorization" {
+			device_id = data.tailscale_device.test_device.node_id
+			authorized = false
+		}`
 
-		if device.Authorized != true {
-			return fmt.Errorf("device with id %q is not authorized", rs.Primary.ID)
+	const testDeviceAuthorizationNextUpdate = `
+		data "tailscale_device" "test_device" {
+			name = "%s"
 		}
+		
+		resource "tailscale_device_authorization" "test_authorization" {
+			device_id = data.tailscale_device.test_device.node_id
+			authorized = true
+		}`
 
-		return nil
+	checkAuthorized := func(wantAuthorized bool) func(client *tailscale.Client, rs *terraform.ResourceState) error {
+		return func(client *tailscale.Client, rs *terraform.ResourceState) error {
+			device, err := client.Devices().Get(context.Background(), rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			if device.Authorized != wantAuthorized {
+				return fmt.Errorf("device with id %q is not authorized", rs.Primary.ID)
+			}
+
+			return nil
+		}
 	}
 
 	checkNodeID := func(client *tailscale.Client, rs *terraform.ResourceState) error {
@@ -134,13 +193,30 @@ func TestAccTailscaleDeviceAuthorization_UsesNodeID(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccProviderFactories(t),
 		// Devices are not currently deauthorized when this resource is deleted,
+		// so if the resource is authorized when the resource gets deleted,
 		// expect that the device both exists and is still authorized.
-		CheckDestroy: checkResourceDestroyed(resourceName, checkAuthorized),
+		CheckDestroy: checkResourceDestroyed(resourceName, checkAuthorized(true)),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testDeviceAuthorization, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Config: fmt.Sprintf(testDeviceAuthorizationCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
 				Check: resource.ComposeTestCheckFunc(
-					checkResourceRemoteProperties(resourceName, checkAuthorized),
+					checkResourceRemoteProperties(resourceName, checkAuthorized(true)),
+					checkResourceRemoteProperties(resourceName, checkNodeID),
+					resource.TestCheckResourceAttr(resourceName, "authorized", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testDeviceAuthorizationUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkAuthorized(false)),
+					checkResourceRemoteProperties(resourceName, checkNodeID),
+					resource.TestCheckResourceAttr(resourceName, "authorized", "false"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testDeviceAuthorizationNextUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkAuthorized(true)),
 					checkResourceRemoteProperties(resourceName, checkNodeID),
 					resource.TestCheckResourceAttr(resourceName, "authorized", "true"),
 				),
@@ -154,10 +230,10 @@ func TestAccTailscaleDeviceAuthorization_UsesNodeID(t *testing.T) {
 	})
 
 	checkResourceIsUnchangedInPluginFramework(t,
-		fmt.Sprintf(testDeviceAuthorization, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+		fmt.Sprintf(testDeviceAuthorizationCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
 		resource.ComposeTestCheckFunc(
 			checkResourceRemoteProperties(resourceName, checkNodeID),
-			checkResourceRemoteProperties(resourceName, checkAuthorized),
+			checkResourceRemoteProperties(resourceName, checkAuthorized(true)),
 			resource.TestCheckResourceAttr(resourceName, "authorized", "true"),
 		),
 	)


### PR DESCRIPTION
This ensures that the state ID gets passed on correctly on Update. Also, previously, the resource didn't support un-authorising a device. We're removing that limitation because it dates from a time when this wasn't supported by the API. The two changes are bundled together because the latter makes adding a test for the former more straightforward.

Updates tailscale/corp#37231

This might also resolve #690. 

Terraform acceptance test: https://github.com/tailscale/corp/actions/runs/24505904516/job/71624246153