### PR TITLE
tailscale: auto-recover from device not found

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -12,11 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"tailscale.com/client/tailscale/v2"
 )
 
 var (
 	_ resource.Resource                = &deviceAuthorizationResource{}
 	_ resource.ResourceWithImportState = &deviceAuthorizationResource{}
+	_ resource.ResourceWithModifyPlan  = &deviceAuthorizationResource{}
 )
 
 type deviceAuthorizationResourceModel struct {
@@ -78,6 +80,12 @@ func (d deviceAuthorizationResource) Read(ctx context.Context, req resource.Read
 
 	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
+		// If the device is not found, remove from the state so we can create it again.
+		if tailscale.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Failed to fetch device authorization",
 			"Failed to fetch authorization for device with with ID "+deviceID+": "+err.Error(),
@@ -153,12 +161,14 @@ func (d deviceAuthorizationResource) Delete(_ context.Context, _ resource.Delete
 	return
 }
 
-func (r deviceAuthorizationResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+func (d deviceAuthorizationResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// If the entire plan is null, the resource is planned for destruction.
 	if req.Plan.Raw.IsNull() {
 		resp.Diagnostics.AddWarning(
 			"Resource Destruction Considerations",
 			"Applying this resource destruction will only remove the resource from the Terraform state and "+
 				"will not modify the device's authorization. ",
 		)
+		return
 	}
 }

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -116,6 +116,12 @@ func (d deviceKeyResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
+		// If the device is not found, remove from the state so we can create it again.
+		if tailscale.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Failed to fetch device key",
 			"Failed to fetch key for device with ID "+deviceID+": "+err.Error(),

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"tailscale.com/client/tailscale/v2"
 )
 
 var (
@@ -77,6 +78,12 @@ func (d deviceTagsResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
+		// If the device is not found, remove from the state so we can create it again.
+		if tailscale.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Failed to fetch device tags",
 			"Failed to fetch device with ID "+deviceID+": "+err.Error(),


### PR DESCRIPTION
Remove a resource from state on Read if the backing device cannot be found. This enables recreation without manual intervention by the user (through `terraform state rm` or similar). We already do this for tailscale_device_subnet_routes, tailscale_service and tailscale_tailnet_key. 

Updates #690

Terraform acceptance test: https://github.com/tailscale/corp/actions/runs/24981486773/job/73144508080