### PR TITLE
data_source_devices: migrate to plugin framework

### DIFF
--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -37,7 +37,7 @@ data "tailscale_devices" "sample_devices" {
 
 ### Read-Only
 
-- `devices` (List of Object) The list of devices in the tailnet (see [below for nested schema](#nestedatt--devices))
+- `devices` (Block List) The list of devices in the tailnet (see [below for nested schema](#nestedblock--devices))
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--filter"></a>
@@ -49,29 +49,29 @@ Required:
 - `values` (Set of String) The list of values to filter for. Values are matched as exact matches.
 
 
-<a id="nestedatt--devices"></a>
+<a id="nestedblock--devices"></a>
 ### Nested Schema for `devices`
 
 Read-Only:
 
-- `addresses` (List of String)
-- `authorized` (Boolean)
-- `blocks_incoming_connections` (Boolean)
-- `client_version` (String)
-- `created` (String)
-- `expires` (String)
-- `hostname` (String)
-- `id` (String)
-- `is_external` (Boolean)
-- `key_expiry_disabled` (Boolean)
-- `last_seen` (String)
-- `machine_key` (String)
-- `name` (String)
-- `node_id` (String)
-- `node_key` (String)
-- `os` (String)
-- `tags` (Set of String)
-- `tailnet_lock_error` (String)
-- `tailnet_lock_key` (String)
-- `update_available` (Boolean)
-- `user` (String)
+- `addresses` (List of String) The list of device's IPs
+- `authorized` (Boolean) Whether the device is authorized to access the tailnet
+- `blocks_incoming_connections` (Boolean) Whether the device blocks incoming connections
+- `client_version` (String) The Tailscale client version running on the device
+- `created` (String) The creation time of the device
+- `expires` (String) The expiry time of the device's key
+- `hostname` (String) The short hostname of the device
+- `id` (String) The ID of this resource.
+- `is_external` (Boolean) Whether the device is marked as external
+- `key_expiry_disabled` (Boolean) Whether the device's key expiry is disabled
+- `last_seen` (String) The last seen time of the device
+- `machine_key` (String) The machine key of the device
+- `name` (String) The full name of the device (e.g. `hostname.domain.ts.net`)
+- `node_id` (String) The preferred indentifier for a device.
+- `node_key` (String) The node key of the device
+- `os` (String) The operating system of the device
+- `tags` (Set of String) The tags applied to the device
+- `tailnet_lock_error` (String) The tailnet lock error for the device, if any
+- `tailnet_lock_key` (String) The tailnet lock key for the device, if any
+- `update_available` (Boolean) Whether an update is available for the device
+- `user` (String) The user associated with the device

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -7,170 +7,74 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"tailscale.com/client/tailscale/v2"
-	"tailscale.com/types/bools"
 )
 
-type deviceDataSourceModel struct {
-	Hostname types.String `tfsdk:"hostname"`
-	Name     types.String `tfsdk:"name"`
-	WaitFor  types.String `tfsdk:"wait_for"`
-
-	Addresses                 types.List   `tfsdk:"addresses"`
-	Authorized                types.Bool   `tfsdk:"authorized"`
-	BlocksIncomingConnections types.Bool   `tfsdk:"blocks_incoming_connections"`
-	ClientVersion             types.String `tfsdk:"client_version"`
-	Created                   types.String `tfsdk:"created"`
-	Expires                   types.String `tfsdk:"expires"`
-	ID                        types.String `tfsdk:"id"`
-	IsExternal                types.Bool   `tfsdk:"is_external"`
-	KeyExpiryDisabled         types.Bool   `tfsdk:"key_expiry_disabled"`
-	LastSeen                  types.String `tfsdk:"last_seen"` // Will be nil if connected_to_control is true.
-	MachineKey                types.String `tfsdk:"machine_key"`
-	NodeID                    types.String `tfsdk:"node_id"` // The preferred identifier for a device.
-	NodeKey                   types.String `tfsdk:"node_key"`
-	OS                        types.String `tfsdk:"os"`
-	Tags                      types.Set    `tfsdk:"tags"`
-	TailnetLockError          types.String `tfsdk:"tailnet_lock_error"`
-	TailnetLockKey            types.String `tfsdk:"tailnet_lock_key"`
-	UpdateAvailable           types.Bool   `tfsdk:"update_available"`
-	User                      types.String `tfsdk:"user"`
+// NewSingleDeviceDataSource returns a new single-device data source.
+func NewSingleDeviceDataSource() datasource.DataSource {
+	return &singleDeviceDataSource{}
 }
 
-// NewDeviceDataSource returns a new Device data source.
-func NewDeviceDataSource() datasource.DataSource {
-	return &deviceDataSource{}
-}
-
-type deviceDataSource struct {
+type singleDeviceDataSource struct {
 	DataSourceBase
 }
 
+type singleDeviceDataSourceModel struct {
+	deviceDataSourceModel
+
+	WaitFor types.String `tfsdk:"wait_for"`
+}
+
 // Metadata defines the data source name as it appears in Terraform configurations.
-func (d deviceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d singleDeviceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_device"
 }
 
 // Schema defines a schema describing what data is available in the data source response.
-func (d deviceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Description: "The device data source describes a single device in a tailnet",
-		Attributes: map[string]schema.Attribute{
-			"name": schema.StringAttribute{
-				Description: "The full name of the device (e.g. `hostname.domain.ts.net`)",
-				Optional:    true,
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.Expressions{
-						path.MatchRoot("name"),
-						path.MatchRoot("hostname"),
-					}...),
-				},
-			},
-			"hostname": schema.StringAttribute{
-				Description: "The short hostname of the device",
-				Optional:    true,
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.Expressions{
-						path.MatchRoot("name"),
-						path.MatchRoot("hostname"),
-					}...),
-				},
-			},
-			"user": schema.StringAttribute{
-				Description: "The user associated with the device",
-				Computed:    true,
-			},
-			"node_id": schema.StringAttribute{
-				Description: "The preferred indentifier for a device.",
-				Computed:    true,
-			},
-			"addresses": schema.ListAttribute{
-				Description: "The list of device's IPs",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"tags": schema.SetAttribute{
-				Description: "The tags applied to the device",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"authorized": schema.BoolAttribute{
-				Description: "Whether the device is authorized to access the tailnet",
-				Computed:    true,
-			},
-			"key_expiry_disabled": schema.BoolAttribute{
-				Description: "Whether the device's key expiry is disabled",
-				Computed:    true,
-			},
-			"blocks_incoming_connections": schema.BoolAttribute{
-				Description: "Whether the device blocks incoming connections",
-				Computed:    true,
-			},
-			"client_version": schema.StringAttribute{
-				Description: "The Tailscale client version running on the device",
-				Computed:    true,
-			},
-			"created": schema.StringAttribute{
-				Description: "The creation time of the device",
-				Computed:    true,
-			},
-			"expires": schema.StringAttribute{
-				Description: "The expiry time of the device's key",
-				Computed:    true,
-			},
-			"id": schema.StringAttribute{
-				Description: "The ID of this resource.",
-				Computed:    true,
-			},
-			"is_external": schema.BoolAttribute{
-				Description: "Whether the device is marked as external",
-				Computed:    true,
-			},
-			"last_seen": schema.StringAttribute{
-				Description: "The last seen time of the device",
-				Computed:    true,
-			},
-			"machine_key": schema.StringAttribute{
-				Description: "The machine key of the device",
-				Computed:    true,
-			},
-			"node_key": schema.StringAttribute{
-				Description: "The node key of the device",
-				Computed:    true,
-			},
-			"os": schema.StringAttribute{
-				Description: "The operating system of the device",
-				Computed:    true,
-			},
-			"update_available": schema.BoolAttribute{
-				Description: "Whether an update is available for the device",
-				Computed:    true,
-			},
-			"tailnet_lock_error": schema.StringAttribute{
-				Description: "The tailnet lock error for the device, if any",
-				Computed:    true,
-			},
-			"tailnet_lock_key": schema.StringAttribute{
-				Description: "The tailnet lock key for the device, if any",
-				Computed:    true,
-			},
-			"wait_for": schema.StringAttribute{
-				Description: "If specified, the provider will make multiple attempts to obtain the data source until the wait_for duration is reached. Retries are made every second so this value should be greater than 1s",
-				Optional:    true,
-				Validators: []validator.String{
-					retryDeadlineValidator{},
-				},
+func (d singleDeviceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attributes := map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Description: "The full name of the device (e.g. `hostname.domain.ts.net`)",
+			Optional:    true,
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(path.Expressions{
+					path.MatchRoot("name"),
+					path.MatchRoot("hostname"),
+				}...),
 			},
 		},
+		"hostname": schema.StringAttribute{
+			Description: "The short hostname of the device",
+			Optional:    true,
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(path.Expressions{
+					path.MatchRoot("name"),
+					path.MatchRoot("hostname"),
+				}...),
+			},
+		},
+		"wait_for": schema.StringAttribute{
+			Description: "If specified, the provider will make multiple attempts to obtain the data source until the wait_for duration is reached. Retries are made every second so this value should be greater than 1s",
+			Optional:    true,
+			Validators: []validator.String{
+				retryDeadlineValidator{},
+			},
+		},
+	}
+	maps.Copy(attributes, deviceSchema)
+
+	resp.Schema = schema.Schema{
+		Description: "The device data source describes a single device in a tailnet",
+		Attributes:  attributes,
 	}
 }
 
@@ -200,8 +104,8 @@ func (r retryDeadlineValidator) ValidateString(_ context.Context, req validator.
 }
 
 // Read fetches the data from the Tailscale API.
-func (d deviceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var device deviceDataSourceModel
+func (d singleDeviceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var device singleDeviceDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &device)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -251,100 +155,14 @@ func (d deviceDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	data, diagnostics := toDeviceDataSourceModel(ctx, selected)
+	apiData, diagnostics := toDeviceDataSourceModel(ctx, selected)
 	if diagnostics.HasError() {
 		resp.Diagnostics.Append(diagnostics...)
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
-}
-
-func toDeviceDataSourceModel(ctx context.Context, device *tailscale.Device) (deviceDataSourceModel, diag.Diagnostics) {
-	var lastSeen string
-	if device.LastSeen == nil {
-		lastSeen = ""
-	} else {
-		lastSeen = device.LastSeen.Format(time.RFC3339)
-	}
-
-	data := deviceDataSourceModel{
-		Hostname: types.StringValue(device.Hostname),
-		Name:     types.StringValue(device.Name),
-
-		Authorized:                types.BoolValue(device.Authorized),
-		BlocksIncomingConnections: types.BoolValue(device.BlocksIncomingConnections),
-		ClientVersion:             types.StringValue(device.ClientVersion),
-		Created:                   types.StringValue(device.Created.Format(time.RFC3339)),
-		Expires:                   types.StringValue(device.Expires.Format(time.RFC3339)),
-		ID:                        types.StringValue(device.ID),
-		IsExternal:                types.BoolValue(device.IsExternal),
-		KeyExpiryDisabled:         types.BoolValue(device.KeyExpiryDisabled),
-		LastSeen:                  types.StringValue(lastSeen),
-		MachineKey:                types.StringValue(device.MachineKey),
-		NodeID:                    types.StringValue(device.NodeID),
-		NodeKey:                   types.StringValue(device.NodeKey),
-		OS:                        types.StringValue(device.OS),
-		TailnetLockError:          types.StringValue(device.TailnetLockError),
-		TailnetLockKey:            types.StringValue(device.TailnetLockKey),
-		UpdateAvailable:           types.BoolValue(device.UpdateAvailable),
-		User:                      types.StringValue(device.User),
-	}
-
-	addresses, diagnostics := types.ListValueFrom(ctx, types.StringType, device.Addresses)
-	if diagnostics.HasError() {
-		return deviceDataSourceModel{}, diagnostics
-	}
-	data.Addresses = addresses
-
-	// Normalize nil to empty slice before converting it to plugin framework
-	// types.
-	// This is to avoid drift when upgrading from a provider version that
-	// is still backed by SDKv2.
-	deviceTags := bools.IfElse(device.Tags != nil, device.Tags, []string{})
-
-	tags, diagnostics := types.SetValueFrom(ctx, types.StringType, deviceTags)
-	if diagnostics.HasError() {
-		return deviceDataSourceModel{}, diagnostics
-	}
-	data.Tags = tags
-
-	return data, diag.Diagnostics{}
-}
-
-// deviceToMap converts the given device into a map representing the device as a
-// resource in Terraform. This omits the "id" which is expected to be set
-// using [schema.ResourceData.SetId].
-func deviceToMap(device *tailscale.Device) map[string]any {
-	var lastSeen string
-	if device.LastSeen == nil {
-		lastSeen = ""
-	} else {
-		lastSeen = device.LastSeen.Format(time.RFC3339)
-	}
-
-	return map[string]any{
-		"name":                        device.Name,
-		"hostname":                    device.Hostname,
-		"user":                        device.User,
-		"node_id":                     device.NodeID,
-		"addresses":                   device.Addresses,
-		"tags":                        device.Tags,
-		"authorized":                  device.Authorized,
-		"key_expiry_disabled":         device.KeyExpiryDisabled,
-		"blocks_incoming_connections": device.BlocksIncomingConnections,
-		"client_version":              device.ClientVersion,
-		"created":                     device.Created.Format(time.RFC3339),
-		"expires":                     device.Expires.Format(time.RFC3339),
-		"is_external":                 device.IsExternal,
-		"last_seen":                   lastSeen,
-		"machine_key":                 device.MachineKey,
-		"node_key":                    device.NodeKey,
-		"os":                          device.OS,
-		"update_available":            device.UpdateAvailable,
-		"tailnet_lock_error":          device.TailnetLockError,
-		"tailnet_lock_key":            device.TailnetLockKey,
-	}
+	device.deviceDataSourceModel = apiData
+	resp.Diagnostics.Append(resp.State.Set(ctx, device)...)
 }
 
 // retryWithDeadline calls fn once. If fn errors and maxWait and retryInterval are positive, it retries fn until fn

--- a/tailscale/data_source_device_test.go
+++ b/tailscale/data_source_device_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/stretchr/testify/assert"
+	"tailscale.com/client/tailscale/v2"
 	tsclient "tailscale.com/client/tailscale/v2"
 	"tailscale.com/tstest"
 )
@@ -243,5 +244,40 @@ func TestRetryWithDeadline_NoRetryWhenWaitForIsZero(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("want no error but got one: %v", err)
+	}
+}
+
+// deviceToMap converts the given device into a map representing the device as a
+// resource in Terraform. This omits the "id" which is expected to be set
+// using [schema.ResourceData.SetId].
+func deviceToMap(device *tailscale.Device) map[string]any {
+	var lastSeen string
+	if device.LastSeen == nil {
+		lastSeen = ""
+	} else {
+		lastSeen = device.LastSeen.Format(time.RFC3339)
+	}
+
+	return map[string]any{
+		"name":                        device.Name,
+		"hostname":                    device.Hostname,
+		"user":                        device.User,
+		"node_id":                     device.NodeID,
+		"addresses":                   device.Addresses,
+		"tags":                        device.Tags,
+		"authorized":                  device.Authorized,
+		"key_expiry_disabled":         device.KeyExpiryDisabled,
+		"blocks_incoming_connections": device.BlocksIncomingConnections,
+		"client_version":              device.ClientVersion,
+		"created":                     device.Created.Format(time.RFC3339),
+		"expires":                     device.Expires.Format(time.RFC3339),
+		"is_external":                 device.IsExternal,
+		"last_seen":                   lastSeen,
+		"machine_key":                 device.MachineKey,
+		"node_key":                    device.NodeKey,
+		"os":                          device.OS,
+		"update_available":            device.UpdateAvailable,
+		"tailnet_lock_error":          device.TailnetLockError,
+		"tailnet_lock_key":            device.TailnetLockKey,
 	}
 }

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -5,212 +5,140 @@ package tailscale
 
 import (
 	"context"
+	"maps"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"tailscale.com/client/tailscale/v2"
 )
 
-func dataSourceDevices() *schema.Resource {
-	return &schema.Resource{
+// NewMultipleDevicesDataSource returns a new multiple-users data data source.
+func NewMultipleDevicesDataSource() datasource.DataSource {
+	return &multipleDevicesDataSource{}
+}
+
+type multipleDevicesDataSource struct {
+	DataSourceBase
+}
+
+type multipleDevicesDataSourceModel struct {
+	ID         types.String            `tfsdk:"id"`
+	NamePrefix types.String            `tfsdk:"name_prefix"`
+	Filters    []filterModel           `tfsdk:"filter"`
+	Devices    []deviceDataSourceModel `tfsdk:"devices"`
+}
+
+type filterModel struct {
+	Name   types.String `tfsdk:"name"`
+	Values types.Set    `tfsdk:"values"`
+}
+
+// Metadata defines the data source name as it appears in Terraform configurations.
+func (d multipleDevicesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_devices"
+}
+
+// Schema defines a schema describing what data is available in the data source response.
+func (d multipleDevicesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	nestedDeviceAttributes := map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+
+			Description: "The full name of the device (e.g. `hostname.domain.ts.net`)",
+			Computed:    true,
+		},
+		"hostname": schema.StringAttribute{
+			Description: "The short hostname of the device",
+			Computed:    true,
+		},
+	}
+	maps.Copy(nestedDeviceAttributes, deviceSchema)
+
+	resp.Schema = schema.Schema{
 		Description: "The devices data source describes a list of devices in a tailnet",
-		ReadContext: dataSourceDevicesRead,
-		Schema: map[string]*schema.Schema{
-			"filter": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:        schema.TypeString,
-							Required:    true,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name_prefix": schema.StringAttribute{
+				Optional:    true,
+				Description: "Filters the device list to elements whose name has the provided prefix",
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"filter": schema.SetNestedBlock{
+				Description: "Filters the device list to elements devices whose fields match the provided values.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
 							Description: "The name must be a top-level device property, e.g. isEphemeral, tags, hostname, etc.",
+							Required:    true,
 						},
-						"values": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+						"values": schema.SetAttribute{
 							Description: "The list of values to filter for. Values are matched as exact matches.",
+							ElementType: types.StringType,
+							Required:    true,
 						},
 					},
 				},
-				Description: "Filters the device list to elements devices whose fields match the provided values.",
 			},
-			"name_prefix": {
-				Optional:    true,
-				Type:        schema.TypeString,
-				Description: "Filters the device list to elements whose name has the provided prefix",
-			},
-			"devices": {
-				Computed:    true,
-				Type:        schema.TypeList,
+			"devices": schema.ListNestedBlock{
 				Description: "The list of devices in the tailnet",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:        schema.TypeString,
-							Description: "The full name of the device (e.g. `hostname.domain.ts.net`)",
-							Computed:    true,
-						},
-						"hostname": {
-							Type:        schema.TypeString,
-							Description: "The short hostname of the device",
-							Computed:    true,
-						},
-						"user": {
-							Type:        schema.TypeString,
-							Description: "The user associated with the device",
-							Computed:    true,
-						},
-						"id": {
-							Type:        schema.TypeString,
-							Description: "The legacy identifier of the device. Use node_id instead for new resources.",
-							Computed:    true,
-						},
-						"node_id": {
-							Type:        schema.TypeString,
-							Description: "The preferred indentifier for a device.",
-							Computed:    true,
-						},
-						"addresses": {
-							Computed:    true,
-							Type:        schema.TypeList,
-							Description: "The list of device's IPs",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"tags": {
-							Type:        schema.TypeSet,
-							Description: "The tags applied to the device",
-							Computed:    true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"authorized": {
-							Type:        schema.TypeBool,
-							Description: "Whether the device is authorized to access the tailnet",
-							Computed:    true,
-						},
-						"key_expiry_disabled": {
-							Type:        schema.TypeBool,
-							Description: "Whether the device's key expiry is disabled",
-							Computed:    true,
-						},
-						"blocks_incoming_connections": {
-							Type:        schema.TypeBool,
-							Description: "Whether the device blocks incoming connections",
-							Computed:    true,
-						},
-						"client_version": {
-							Type:        schema.TypeString,
-							Description: "The Tailscale client version running on the device",
-							Computed:    true,
-						},
-						"created": {
-							Type:        schema.TypeString,
-							Description: "The creation time of the device",
-							Computed:    true,
-						},
-						"expires": {
-							Type:        schema.TypeString,
-							Description: "The expiry time of the device's key",
-							Computed:    true,
-						},
-						"is_external": {
-							Type:        schema.TypeBool,
-							Description: "Whether the device is marked as external",
-							Computed:    true,
-						},
-						"last_seen": {
-							Type:        schema.TypeString,
-							Description: "The last seen time of the device",
-							Computed:    true,
-						},
-						"machine_key": {
-							Type:        schema.TypeString,
-							Description: "The machine key of the device",
-							Computed:    true,
-						},
-						"node_key": {
-							Type:        schema.TypeString,
-							Description: "The node key of the device",
-							Computed:    true,
-						},
-						"os": {
-							Type:        schema.TypeString,
-							Description: "The operating system of the device",
-							Computed:    true,
-						},
-						"update_available": {
-							Type:        schema.TypeBool,
-							Description: "Whether an update is available for the device",
-							Computed:    true,
-						},
-						"tailnet_lock_error": {
-							Type:        schema.TypeString,
-							Description: "The tailnet lock error for the device, if any",
-							Computed:    true,
-						},
-						"tailnet_lock_key": {
-							Type:        schema.TypeString,
-							Description: "The tailnet lock key for the device, if any",
-							Computed:    true,
-						},
-					},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: nestedDeviceAttributes,
 				},
 			},
 		},
 	}
 }
 
-func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+// Read fetches the data from the Tailscale API.
+func (d multipleDevicesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data multipleDevicesDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	opts := []tailscale.ListDevicesOptions{}
-	if v, ok := d.GetOk("filter"); ok {
-		filterConfigs := v.(*schema.Set).List()
-		for _, f := range filterConfigs {
-			m := f.(map[string]interface{})
-			name := m["name"].(string)
+	opts := make([]tailscale.ListDevicesOptions, 0, len(data.Filters))
+	for _, f := range data.Filters {
+		var values []string
 
-			// Convert the Set of values to a slice of strings
-			rawValues := m["values"].(*schema.Set).List()
-			values := make([]string, len(rawValues))
-			for i, val := range rawValues {
-				values[i] = val.(string)
-			}
-
-			opts = append(opts, tailscale.WithFilter(name, values))
+		diags := f.Values.ElementsAs(ctx, &values, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
+
+		opts = append(opts, tailscale.WithFilter(f.Name.ValueString(), values))
 	}
 
-	devices, err := client.Devices().List(ctx, opts...)
+	devices, err := d.Client.Devices().List(ctx, opts...)
 	if err != nil {
-		return diagnosticsError(err, "Failed to fetch devices")
+		resp.Diagnostics.AddError("Failed to fetch devices", err.Error())
+		return
 	}
 
-	namePrefix, _ := d.Get("name_prefix").(string)
-	deviceMaps := make([]map[string]interface{}, 0)
-	for _, device := range devices {
-		if namePrefix != "" && !strings.HasPrefix(device.Name, namePrefix) {
+	prefix := data.NamePrefix.ValueString()
+	data.Devices = make([]deviceDataSourceModel, 0)
+
+	for _, dev := range devices {
+		if prefix != "" && !strings.HasPrefix(dev.Name, prefix) {
 			continue
 		}
 
-		m := deviceToMap(&device)
-		m["id"] = device.ID
-		deviceMaps = append(deviceMaps, m)
+		deviceModel, diagnostics := toDeviceDataSourceModel(ctx, &dev)
+		if diagnostics.HasError() {
+			resp.Diagnostics.Append(diagnostics...)
+			return
+		}
+
+		data.Devices = append(data.Devices, deviceModel)
 	}
 
-	if err = d.Set("devices", deviceMaps); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(createUUID())
-	return nil
+	data.ID = types.StringValue(createUUID())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/tailscale/model_device.go
+++ b/tailscale/model_device.go
@@ -1,0 +1,173 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"tailscale.com/client/tailscale/v2"
+	"tailscale.com/types/bools"
+)
+
+type deviceDataSourceModel struct {
+	Hostname types.String `tfsdk:"hostname"`
+	Name     types.String `tfsdk:"name"`
+
+	Addresses                 types.List   `tfsdk:"addresses"`
+	Authorized                types.Bool   `tfsdk:"authorized"`
+	BlocksIncomingConnections types.Bool   `tfsdk:"blocks_incoming_connections"`
+	ClientVersion             types.String `tfsdk:"client_version"`
+	Created                   types.String `tfsdk:"created"`
+	Expires                   types.String `tfsdk:"expires"`
+	ID                        types.String `tfsdk:"id"`
+	IsExternal                types.Bool   `tfsdk:"is_external"`
+	KeyExpiryDisabled         types.Bool   `tfsdk:"key_expiry_disabled"`
+	LastSeen                  types.String `tfsdk:"last_seen"` // Will be nil if connected_to_control is true.
+	MachineKey                types.String `tfsdk:"machine_key"`
+	NodeID                    types.String `tfsdk:"node_id"` // The preferred identifier for a device.
+	NodeKey                   types.String `tfsdk:"node_key"`
+	OS                        types.String `tfsdk:"os"`
+	Tags                      types.Set    `tfsdk:"tags"`
+	TailnetLockError          types.String `tfsdk:"tailnet_lock_error"`
+	TailnetLockKey            types.String `tfsdk:"tailnet_lock_key"`
+	UpdateAvailable           types.Bool   `tfsdk:"update_available"`
+	User                      types.String `tfsdk:"user"`
+}
+
+func toDeviceDataSourceModel(ctx context.Context, device *tailscale.Device) (deviceDataSourceModel, diag.Diagnostics) {
+	var lastSeen string
+	if device.LastSeen == nil {
+		lastSeen = ""
+	} else {
+		lastSeen = device.LastSeen.Format(time.RFC3339)
+	}
+
+	data := deviceDataSourceModel{
+		Hostname: types.StringValue(device.Hostname),
+		Name:     types.StringValue(device.Name),
+
+		Authorized:                types.BoolValue(device.Authorized),
+		BlocksIncomingConnections: types.BoolValue(device.BlocksIncomingConnections),
+		ClientVersion:             types.StringValue(device.ClientVersion),
+		Created:                   types.StringValue(device.Created.Format(time.RFC3339)),
+		Expires:                   types.StringValue(device.Expires.Format(time.RFC3339)),
+		ID:                        types.StringValue(device.ID),
+		IsExternal:                types.BoolValue(device.IsExternal),
+		KeyExpiryDisabled:         types.BoolValue(device.KeyExpiryDisabled),
+		LastSeen:                  types.StringValue(lastSeen),
+		MachineKey:                types.StringValue(device.MachineKey),
+		NodeID:                    types.StringValue(device.NodeID),
+		NodeKey:                   types.StringValue(device.NodeKey),
+		OS:                        types.StringValue(device.OS),
+		TailnetLockError:          types.StringValue(device.TailnetLockError),
+		TailnetLockKey:            types.StringValue(device.TailnetLockKey),
+		UpdateAvailable:           types.BoolValue(device.UpdateAvailable),
+		User:                      types.StringValue(device.User),
+	}
+
+	addresses, diagnostics := types.ListValueFrom(ctx, types.StringType, device.Addresses)
+	if diagnostics.HasError() {
+		return deviceDataSourceModel{}, diagnostics
+	}
+	data.Addresses = addresses
+
+	// Normalize nil to empty slice before converting it to plugin framework
+	// types.
+	// This is to avoid drift when upgrading from a provider version that
+	// is still backed by SDKv2.
+	deviceTags := bools.IfElse(device.Tags != nil, device.Tags, []string{})
+
+	tags, diagnostics := types.SetValueFrom(ctx, types.StringType, deviceTags)
+	if diagnostics.HasError() {
+		return deviceDataSourceModel{}, diagnostics
+	}
+	data.Tags = tags
+
+	return data, diag.Diagnostics{}
+}
+
+var deviceSchema = map[string]schema.Attribute{
+	"user": schema.StringAttribute{
+		Description: "The user associated with the device",
+		Computed:    true,
+	},
+	"node_id": schema.StringAttribute{
+		Description: "The preferred indentifier for a device.",
+		Computed:    true,
+	},
+	"addresses": schema.ListAttribute{
+		Description: "The list of device's IPs",
+		Computed:    true,
+		ElementType: types.StringType,
+	},
+	"tags": schema.SetAttribute{
+		Description: "The tags applied to the device",
+		Computed:    true,
+		ElementType: types.StringType,
+	},
+	"authorized": schema.BoolAttribute{
+		Description: "Whether the device is authorized to access the tailnet",
+		Computed:    true,
+	},
+	"key_expiry_disabled": schema.BoolAttribute{
+		Description: "Whether the device's key expiry is disabled",
+		Computed:    true,
+	},
+	"blocks_incoming_connections": schema.BoolAttribute{
+		Description: "Whether the device blocks incoming connections",
+		Computed:    true,
+	},
+	"client_version": schema.StringAttribute{
+		Description: "The Tailscale client version running on the device",
+		Computed:    true,
+	},
+	"created": schema.StringAttribute{
+		Description: "The creation time of the device",
+		Computed:    true,
+	},
+	"expires": schema.StringAttribute{
+		Description: "The expiry time of the device's key",
+		Computed:    true,
+	},
+	"id": schema.StringAttribute{
+		Description: "The ID of this resource.",
+		Computed:    true,
+	},
+	"is_external": schema.BoolAttribute{
+		Description: "Whether the device is marked as external",
+		Computed:    true,
+	},
+	"last_seen": schema.StringAttribute{
+		Description: "The last seen time of the device",
+		Computed:    true,
+	},
+	"machine_key": schema.StringAttribute{
+		Description: "The machine key of the device",
+		Computed:    true,
+	},
+	"node_key": schema.StringAttribute{
+		Description: "The node key of the device",
+		Computed:    true,
+	},
+	"os": schema.StringAttribute{
+		Description: "The operating system of the device",
+		Computed:    true,
+	},
+	"update_available": schema.BoolAttribute{
+		Description: "Whether an update is available for the device",
+		Computed:    true,
+	},
+	"tailnet_lock_error": schema.StringAttribute{
+		Description: "The tailnet lock error for the device, if any",
+		Computed:    true,
+	},
+	"tailnet_lock_key": schema.StringAttribute{
+		Description: "The tailnet lock key for the device, if any",
+		Computed:    true,
+	},
+}

--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -191,9 +191,10 @@ func (p *tailscaleProvider) DataSources(_ context.Context) []func() datasource.D
 	return []func() datasource.DataSource{
 		New4Via6DataSource,
 		NewACLDataSource,
-		NewDeviceDataSource,
 		NewMultipleUsersDataSource,
 		NewSingleUserDataSource,
+		NewMultipleDevicesDataSource,
+		NewSingleDeviceDataSource,
 	}
 }
 

--- a/tailscale/provider_sdk.go
+++ b/tailscale/provider_sdk.go
@@ -107,7 +107,6 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"tailscale_service":                 resourceService(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"tailscale_devices": dataSourceDevices(),
 			"tailscale_service": dataSourceService(),
 		},
 	}


### PR DESCRIPTION
I copied some of the ideas from #700 and the `data_source_{user, users}` resources – rather than duplicating the schema in both files, we can reuse it and get the benefit of improved documentation to boot!

Fixes tailscale/corp#37225