### PR TITLE
CONTRIBUTING.md: document updated Go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ the pull request it relates to.
 
 ## Making Changes
 
-To work in this repository, you will need go 1.25. You can use the standard go toolchain for building and testing your
+To work in this repository, you will need go 1.26. You can use the standard go toolchain for building and testing your
 changes. 
 
 If you want to enable acceptance tests, you *must* set the `TF_ACC` environment variable. 


### PR DESCRIPTION
Very minor, bumped the Go version in the contributing docs to match what's in `go.mod`.

Test plan: n/a, docs only
