### PR TITLE
data_source_devices: sanitize device names used as resource names in tests

### DIFF
--- a/tailscale/data_source_devices_test.go
+++ b/tailscale/data_source_devices_test.go
@@ -6,6 +6,7 @@ package tailscale
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -26,7 +27,8 @@ func TestAccTailscaleDevices(t *testing.T) {
 	devicesTerraformData := &strings.Builder{}
 
 	toResourceComponent := func(str string) string {
-		return strings.ReplaceAll(str, " ", "_")
+		rx := regexp.MustCompile(`[^0-9a-zA-Z_-]+`)
+		return rx.ReplaceAllString(str, "_")
 	}
 
 	// First test the tailscale_devices datasource, which will give us a list of


### PR DESCRIPTION
**What this PR does / why we need it**:

In acceptance tests, the name of the pre-existing node given to the test is used as the resource name in the Terraform the test generates. It errors if your device's name contains, for example, brackets:

```
--- FAIL: TestAccTailscaleDevices (0.98s)
    data_source_devices_test.go:93: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid data resource name

          on terraform_plugin_test.tf line 6, in data "tailscale_device" "James’s_MacBook_Pro_(2)":
           6: data "tailscale_device" "James’s_MacBook_Pro_(2)" {

        A name must start with a letter or underscore and may contain only letters,
        digits, underscores, and dashes.
    testing_new.go:74: Error retrieving state, there may be dangling resources: exit status 1

        Error: Invalid data resource name

          on terraform_plugin_test.tf line 6, in data "tailscale_device" "James’s_MacBook_Pro_(2)":
           6: data "tailscale_device" "James’s_MacBook_Pro_(2)" {

        A name must start with a letter or underscore and may contain only letters,
        digits, underscores, and dashes.
FAIL
FAIL    github.com/tailscale/terraform-provider-tailscale/tailscale     1.459s
FAIL
```

Test plan: run TestAccTailscaleDevices with `TAILSCALE_TEST_DEVICE_NAME` set to a device that has disallowed characters (other than spaces, which were already replaced) in its name. The test should pass.