### PR TITLE
resource_posture_integration: migrate to plugin framework

### DIFF
--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -15,8 +15,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"tailscale.com/client/tailscale/v2"
+)
+
+var (
+	_ planmodifier.String = PreserveEmptyStringAsNull{}
 )
 
 type tailscaleProvider struct {
@@ -176,6 +181,7 @@ func (p *tailscaleProvider) Resources(_ context.Context) []func() resource.Resou
 		NewDNSPreferencesResource,
 		NewDNSSearchPathsResource,
 		NewDNSSplitNameserversResource,
+		NewPostureIntegrationResource,
 		NewWebhookResource,
 	}
 }
@@ -238,5 +244,66 @@ func createTailscaleClient(baseURL *url.URL, userAgent string, tailnet string, a
 			APIKey:    apiKey,
 			Tailnet:   tailnet,
 		}
+	}
+}
+
+// StringValueNullIfEmpty returns a StringValue of the given input string, or a
+// null StringValue if the input string is empty. Useful for cases where ""
+// being returned from the API is equivalent to an unset / null value in the
+// Terraform state.
+func StringValueNullIfEmpty(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	} else {
+		return types.StringValue(s)
+	}
+}
+
+// CoalesceStringEmptyOrNull returns a StringValue based on both the new string
+// value we have received, and the existing value in state, ensuring that we
+// won't set a null string to an empty string, or vice-versa. This is useful in
+// cases where null and empty strings are equivalent as far as the client or API
+// are concerned, and we want to avoid Terraform thinking there is a diff if
+// e.g. the API returns "" but the state has null.
+//
+// If newValue is a non-empty string, this will always return a StringValue of
+// that string.
+//
+// If newValue is empty, and the current value in state is null or empty, it
+// will return the existing stateValue, ensuring the update is no-op.
+//
+// Otherwise, this follows the rules of [StringValueNullIfEmpty], and will
+// return a null StringValue if newValue is empty, and a StringValue of newValue
+// otherwise.
+func CoalesceStringEmptyOrNull(stateValue types.String, newValue string) types.String {
+	if newValue == "" && stateValue.ValueString() == "" && !stateValue.IsUnknown() {
+		return stateValue
+	}
+	return StringValueNullIfEmpty(newValue)
+}
+
+// PreserveEmptyStringAsNull is a plan modifier that will treat empty strings in
+// the state as equivalent to null values, and not change them. This is needed
+// because the plugin SDK provider may have saved empty strings in the state for
+// certain attributes when set to null, but the plugin framework-based provider
+// will always save null strings as null. In cases where the empty string and
+// null are equivalent as far as the client or API are concerned, we therefore
+// need to change the plan to avoid changing an empty string to a null, and a
+// confusing no-op diff from Terraform. For more details, see:
+//   - https://github.com/hashicorp/terraform-plugin-framework/issues/510
+//   - https://discuss.hashicorp.com/t/framework-migration-test-produces-non-empty-plan/54523/12
+type PreserveEmptyStringAsNull struct{}
+
+func (pm PreserveEmptyStringAsNull) Description(_ context.Context) string {
+	return `If the existing value of this attribute in state is "" and the new value is null, the value of this attribute in state will remain as the empty string.`
+}
+
+func (pm PreserveEmptyStringAsNull) MarkdownDescription(_ context.Context) string {
+	return `If the existing value of this attribute in state is "" and the new value is null, the value of this attribute in state will remain as the empty string.`
+}
+
+func (pm PreserveEmptyStringAsNull) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.ValueString() == "" && !req.StateValue.IsUnknown() && req.ConfigValue.IsNull() {
+		resp.PlanValue = types.StringValue("")
 	}
 }

--- a/tailscale/provider_sdk.go
+++ b/tailscale/provider_sdk.go
@@ -101,7 +101,6 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"tailscale_tailnet_key":             resourceTailnetKey(),
 			"tailscale_oauth_client":            resourceOAuthClient(),
 			"tailscale_contacts":                resourceContacts(),
-			"tailscale_posture_integration":     resourcePostureIntegration(),
 			"tailscale_logstream_configuration": resourceLogstreamConfiguration(),
 			"tailscale_tailnet_settings":        resourceTailnetSettings(),
 			"tailscale_federated_identity":      resourceFederatedIdentity(),

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -377,6 +377,7 @@ func checkDataSourceIsUnchangedInPluginFramework(t *testing.T, config string) {
 //
 // See https://developer.hashicorp.com/terraform/plugin/framework/migrating/testing#external-providers
 func checkResourceIsUnchangedInPluginFramework(t *testing.T, config string, check resource.TestCheckFunc) {
+	t.Helper()
 	resource.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -5,32 +5,65 @@ package tailscale
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"tailscale.com/client/tailscale/v2"
 )
 
-func resourcePostureIntegration() *schema.Resource {
-	return &schema.Resource{
-		Description:   "The posture_integration resource allows you to manage integrations with device posture data providers. See https://tailscale.com/kb/1288/device-posture for more information.",
-		ReadContext:   resourcePostureIntegrationRead,
-		CreateContext: resourcePostureIntegrationCreate,
-		UpdateContext: resourcePostureIntegrationUpdate,
-		DeleteContext: resourcePostureIntegrationDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"posture_provider": {
-				Type:        schema.TypeString,
-				Description: "The third-party provider for posture data. Valid values are `falcon`, `fleet`, `huntress`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.",
-				Required:    true,
-				ForceNew:    true,
-				ValidateFunc: validation.StringInSlice(
-					[]string{
+var (
+	_ resource.Resource                = &postureIntegrationResource{}
+	_ resource.ResourceWithConfigure   = &postureIntegrationResource{}
+	_ resource.ResourceWithImportState = &postureIntegrationResource{}
+)
+
+type postureIntegrationResourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	PostureProvider types.String `tfsdk:"posture_provider"`
+	CloudID         types.String `tfsdk:"cloud_id"`
+	ClientID        types.String `tfsdk:"client_id"`
+	TenantID        types.String `tfsdk:"tenant_id"`
+	ClientSecret    types.String `tfsdk:"client_secret"`
+}
+
+func NewPostureIntegrationResource() resource.Resource {
+	return &postureIntegrationResource{}
+}
+
+type postureIntegrationResource struct {
+	ResourceBase
+}
+
+func (p *postureIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (p *postureIntegrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_posture_integration"
+}
+
+func (p *postureIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "The posture_integration resource allows you to manage integrations with device posture data providers. See https://tailscale.com/kb/1288/device-posture for more information.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"posture_provider": schema.StringAttribute{
+				Description:   "The third-party provider for posture data. Valid values are `falcon`, `fleet`, `huntress`, `intune`, `jamfpro`, `kandji`, `kolide`, and `sentinelone`.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.OneOf(
 						string(tailscale.PostureIntegrationProviderFalcon),
 						string(tailscale.PostureIntegrationProviderFleet),
 						string(tailscale.PostureIntegrationProviderHuntress),
@@ -39,27 +72,28 @@ func resourcePostureIntegration() *schema.Resource {
 						string(tailscale.PostureIntegrationProviderKandji),
 						string(tailscale.PostureIntegrationProviderKolide),
 						string(tailscale.PostureIntegrationProviderSentinelOne),
-					},
-					false,
-				),
+					),
+				},
 			},
-			"cloud_id": {
-				Type:        schema.TypeString,
-				Description: "Identifies which of the provider's clouds to integrate with.",
-				Optional:    true,
+			"cloud_id": schema.StringAttribute{
+				Description:   "Identifies which of the provider's clouds to integrate with.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
 			},
-			"client_id": {
-				Type:        schema.TypeString,
-				Description: "Unique identifier for your client.",
-				Optional:    true,
+			"client_id": schema.StringAttribute{
+				Description:   "Unique identifier for your client.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
 			},
-			"tenant_id": {
-				Type:        schema.TypeString,
-				Description: "The Microsoft Intune directory (tenant) ID. For other providers, this is left blank.",
-				Optional:    true,
+			"tenant_id": schema.StringAttribute{
+				Description:   "The Microsoft Intune directory (tenant) ID. For other providers, this is left blank.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
 			},
-			"client_secret": {
-				Type:        schema.TypeString,
+			"client_secret": schema.StringAttribute{
 				Description: "The secret (auth key, token, etc.) used to authenticate with the provider.",
 				Required:    true,
 				Sensitive:   true,
@@ -68,80 +102,100 @@ func resourcePostureIntegration() *schema.Resource {
 	}
 }
 
-func resourcePostureIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+func (p *postureIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state postureIntegrationResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	integration, err := client.DevicePosture().GetIntegration(ctx, d.Id())
+	integration, err := p.Client.DevicePosture().GetIntegration(ctx, state.ID.ValueString())
 	if err != nil {
-		return diagnosticsError(err, "Failed to find posture integration with id %q", d.Id())
+		resp.Diagnostics.AddError("Failed to fetch posture integration",
+			fmt.Sprintf("Error reading posture integration with id %q: %s", state.ID.ValueString(), err.Error()))
+		return
 	}
-	return resourcePostureIntegrationUpdateFromRemote(d, integration)
+
+	state.ID = types.StringValue(integration.ID)
+	state.PostureProvider = types.StringValue(string(integration.Provider))
+	state.CloudID = CoalesceStringEmptyOrNull(state.CloudID, integration.CloudID)
+	state.ClientID = CoalesceStringEmptyOrNull(state.ClientID, integration.ClientID)
+	state.TenantID = CoalesceStringEmptyOrNull(state.TenantID, integration.TenantID)
+
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
 }
 
-func resourcePostureIntegrationUpdateFromRemote(d *schema.ResourceData, integration *tailscale.PostureIntegration) diag.Diagnostics {
-	if err := d.Set("posture_provider", string(integration.Provider)); err != nil {
-		return diagnosticsError(err, "Failed to set posture_provider field")
+func (p *postureIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan postureIntegrationResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	if err := d.Set("cloud_id", string(integration.CloudID)); err != nil {
-		return diagnosticsError(err, "Failed to set cloud_id field")
-	}
-	if err := d.Set("client_id", string(integration.ClientID)); err != nil {
-		return diagnosticsError(err, "Failed to set client_id field")
-	}
-	if err := d.Set("tenant_id", string(integration.TenantID)); err != nil {
-		return diagnosticsError(err, "Failed to set tenant_id field")
-	}
-
-	return nil
-}
-
-func resourcePostureIntegrationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
-
-	integration, err := client.DevicePosture().CreateIntegration(
+	integration, err := p.Client.DevicePosture().CreateIntegration(
 		ctx,
 		tailscale.CreatePostureIntegrationRequest{
-			Provider:     tailscale.PostureIntegrationProvider(d.Get("posture_provider").(string)),
-			CloudID:      d.Get("cloud_id").(string),
-			ClientID:     d.Get("client_id").(string),
-			TenantID:     d.Get("tenant_id").(string),
-			ClientSecret: d.Get("client_secret").(string),
+			Provider:     tailscale.PostureIntegrationProvider(plan.PostureProvider.ValueString()),
+			CloudID:      plan.CloudID.ValueString(),
+			ClientID:     plan.ClientID.ValueString(),
+			TenantID:     plan.TenantID.ValueString(),
+			ClientSecret: plan.ClientSecret.ValueString(),
+		},
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create posture integration",
+			fmt.Sprintf("Error creating posture integration with provider %q: %s", plan.PostureProvider.ValueString(), err.Error()))
+		return
+	}
+
+	plan.ID = types.StringValue(integration.ID)
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (p *postureIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan postureIntegrationResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := p.Client.DevicePosture().UpdateIntegration(
+		ctx,
+		plan.ID.ValueString(),
+		tailscale.UpdatePostureIntegrationRequest{
+			CloudID:      plan.CloudID.ValueString(),
+			ClientID:     plan.ClientID.ValueString(),
+			TenantID:     plan.TenantID.ValueString(),
+			ClientSecret: plan.ClientSecret.ValueStringPointer(),
 		},
 	)
 	if err != nil {
-		return diagnosticsError(err, "Failed to create posture integration")
+		resp.Diagnostics.AddError("Failed to update posture integration",
+			fmt.Sprintf("Error updating posture integration with id %q: %s", plan.ID.ValueString(), err.Error()))
+		return
 	}
 
-	d.SetId(integration.ID)
-	return resourcePostureIntegrationUpdateFromRemote(d, integration)
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
 }
 
-func resourcePostureIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
-
-	integration, err := client.DevicePosture().UpdateIntegration(
-		ctx,
-		d.Id(),
-		tailscale.UpdatePostureIntegrationRequest{
-			CloudID:      d.Get("cloud_id").(string),
-			ClientID:     d.Get("client_id").(string),
-			TenantID:     d.Get("tenant_id").(string),
-			ClientSecret: tailscale.PointerTo(d.Get("client_secret").(string)),
-		})
-	if err != nil {
-		return diagnosticsError(err, "Failed to update posture integration with id %q", d.Id())
+func (p *postureIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var plan postureIntegrationResourceModel
+	diags := req.State.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return resourcePostureIntegrationUpdateFromRemote(d, integration)
-}
-
-func resourcePostureIntegrationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
-
-	err := client.DevicePosture().DeleteIntegration(ctx, d.Id())
+	err := p.Client.DevicePosture().DeleteIntegration(ctx, plan.ID.ValueString())
 	if err != nil {
-		return diagnosticsError(err, "Failed to delete posture integration with id %q", d.Id())
+		resp.Diagnostics.AddError("Failed to delete posture integration",
+			fmt.Sprintf("Error deleting posture integration with id %q: %s", plan.ID.ValueString(), err.Error()))
+		return
 	}
-
-	return nil
 }

--- a/tailscale/resource_posture_integration_test.go
+++ b/tailscale/resource_posture_integration_test.go
@@ -39,32 +39,62 @@ const testPostureIntegrationUpdateDifferentProvider = `
 		client_secret         = "test-secret3"
 	}`
 
+const testPostureIntegrationCreateNoOptionalFields = `
+	resource "tailscale_posture_integration" "test_posture_integration" {
+		posture_provider      = "kolide"
+		client_secret         = "test-secret1"
+	}`
+
+const testPostureIntegrationUpdateNoOptionalFields = `
+	resource "tailscale_posture_integration" "test_posture_integration" {
+		posture_provider      = "kolide"
+		client_secret         = "test-secret2"
+	}`
+
+const testPostureIntegrationCreateEmptyOptionalFields = `
+	resource "tailscale_posture_integration" "test_posture_integration" {
+		posture_provider      = "kolide"
+		client_secret         = "test-secret1"
+		cloud_id              = ""
+		client_id             = ""
+		tenant_id             = ""
+	}`
+
+const testPostureIntegrationUpdateEmptyOptionalFields = `
+	resource "tailscale_posture_integration" "test_posture_integration" {
+		posture_provider      = "kolide"
+		client_secret         = "test-secret2"
+		cloud_id              = ""
+		client_id             = ""
+		tenant_id             = ""
+	}`
+
+func testPostureCheckProperties(expected tailscale.PostureIntegration) func(client *tailscale.Client, rs *terraform.ResourceState) error {
+	return func(client *tailscale.Client, rs *terraform.ResourceState) error {
+		integration, err := client.DevicePosture().GetIntegration(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if integration.Provider != expected.Provider {
+			return fmt.Errorf("wrong provider, want %q got %q", expected.Provider, integration.Provider)
+		}
+		if integration.CloudID != expected.CloudID {
+			return fmt.Errorf("wrong cloud_id, want %q got %q", expected.CloudID, integration.CloudID)
+		}
+		if integration.ClientID != expected.ClientID {
+			return fmt.Errorf("wrong client_id, want %q got %q", expected.ClientID, integration.ClientID)
+		}
+		if integration.TenantID != expected.TenantID {
+			return fmt.Errorf("wrong tenant_id, want %q got %q", expected.TenantID, integration.TenantID)
+		}
+
+		return nil
+	}
+}
+
 func TestAccTailscalePostureIntegration(t *testing.T) {
 	const resourceName = "tailscale_posture_integration.test_posture_integration"
-
-	checkProperties := func(expected tailscale.PostureIntegration) func(client *tailscale.Client, rs *terraform.ResourceState) error {
-		return func(client *tailscale.Client, rs *terraform.ResourceState) error {
-			integration, err := client.DevicePosture().GetIntegration(context.Background(), rs.Primary.ID)
-			if err != nil {
-				return err
-			}
-
-			if integration.Provider != expected.Provider {
-				return fmt.Errorf("wrong provider, want %q got %q", expected.Provider, integration.Provider)
-			}
-			if integration.CloudID != expected.CloudID {
-				return fmt.Errorf("wrong cloud_id, want %q got %q", expected.CloudID, integration.CloudID)
-			}
-			if integration.ClientID != expected.ClientID {
-				return fmt.Errorf("wrong client_id, want %q got %q", expected.ClientID, integration.ClientID)
-			}
-			if integration.TenantID != expected.TenantID {
-				return fmt.Errorf("wrong tenant_id, want %q got %q", expected.TenantID, integration.TenantID)
-			}
-
-			return nil
-		}
-	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -82,7 +112,7 @@ func TestAccTailscalePostureIntegration(t *testing.T) {
 				Config: testPostureIntegrationCreate,
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceRemoteProperties(resourceName,
-						checkProperties(tailscale.PostureIntegration{
+						testPostureCheckProperties(tailscale.PostureIntegration{
 							Provider: tailscale.PostureIntegrationProviderFalcon,
 							CloudID:  "us-1",
 							ClientID: "clientid1",
@@ -98,7 +128,7 @@ func TestAccTailscalePostureIntegration(t *testing.T) {
 				Config: testPostureIntegrationUpdateSameProvider,
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceRemoteProperties(resourceName,
-						checkProperties(tailscale.PostureIntegration{
+						testPostureCheckProperties(tailscale.PostureIntegration{
 							Provider: tailscale.PostureIntegrationProviderFalcon,
 							CloudID:  "us-2",
 							ClientID: "clientid2",
@@ -114,7 +144,7 @@ func TestAccTailscalePostureIntegration(t *testing.T) {
 				Config: testPostureIntegrationUpdateDifferentProvider,
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceRemoteProperties(resourceName,
-						checkProperties(tailscale.PostureIntegration{
+						testPostureCheckProperties(tailscale.PostureIntegration{
 							Provider: tailscale.PostureIntegrationProviderIntune,
 							CloudID:  "global",
 							ClientID: "fddf23ae-0e3a-4e0c-908d-6f44e80f9400",
@@ -136,4 +166,102 @@ func TestAccTailscalePostureIntegration(t *testing.T) {
 			},
 		},
 	})
+
+}
+
+// TestAccTailscalePostureIntegrationOptionalFields checks that we can
+// round-trip set / update / read any of the fields that are optional strings
+// without getting complaints that they are changing between null and
+// StringVal("").
+func TestAccTailscalePostureIntegrationOptionalFields(t *testing.T) {
+	const resourceName = "tailscale_posture_integration.test_posture_integration"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy: checkResourceDestroyed(resourceName, func(client *tailscale.Client, rs *terraform.ResourceState) error {
+			_, err := client.DevicePosture().GetIntegration(context.Background(), rs.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("posture integration %q still exists on server", resourceName)
+			}
+
+			return nil
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: testPostureIntegrationCreateNoOptionalFields,
+			},
+			{
+				Config:   testPostureIntegrationCreateEmptyOptionalFields,
+				PlanOnly: true,
+			},
+			{
+				Config: testPostureIntegrationUpdateNoOptionalFields,
+			},
+			{
+				Config:   testPostureIntegrationUpdateEmptyOptionalFields,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccTailscalePostureIntegrationMigration(t *testing.T) {
+	const resourceName = "tailscale_posture_integration.test_posture_integration"
+
+	// no-op test case to configure client
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: " ",
+			},
+		},
+	})
+
+	// Test that migration works with every optional field unset
+	checkResourceIsUnchangedInPluginFramework(t,
+		testPostureIntegrationCreateNoOptionalFields,
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName,
+				testPostureCheckProperties(tailscale.PostureIntegration{
+					Provider: tailscale.PostureIntegrationProviderKolide,
+				}),
+			),
+			resource.TestCheckResourceAttr(resourceName, "posture_provider", "kolide"),
+			resource.TestCheckResourceAttr(resourceName, "client_secret", "test-secret1"),
+		))
+
+	// Test that migration works with every optional field set to the empty string
+	checkResourceIsUnchangedInPluginFramework(t,
+		testPostureIntegrationCreateEmptyOptionalFields,
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName,
+				testPostureCheckProperties(tailscale.PostureIntegration{
+					Provider: tailscale.PostureIntegrationProviderKolide,
+				}),
+			),
+			resource.TestCheckResourceAttr(resourceName, "posture_provider", "kolide"),
+			resource.TestCheckResourceAttr(resourceName, "client_secret", "test-secret1"),
+		))
+
+	// Test that migration works with every single field set
+	checkResourceIsUnchangedInPluginFramework(t,
+		testPostureIntegrationUpdateDifferentProvider,
+		resource.ComposeTestCheckFunc(
+			checkResourceRemoteProperties(resourceName,
+				testPostureCheckProperties(tailscale.PostureIntegration{
+					Provider: tailscale.PostureIntegrationProviderIntune,
+					CloudID:  "global",
+					ClientID: "fddf23ae-0e3a-4e0c-908d-6f44e80f9400",
+					TenantID: "fddf23ae-0e3a-4e0c-908d-6f44e80f9401",
+				}),
+			),
+			resource.TestCheckResourceAttr(resourceName, "posture_provider", "intune"),
+			resource.TestCheckResourceAttr(resourceName, "cloud_id", "global"),
+			resource.TestCheckResourceAttr(resourceName, "client_id", "fddf23ae-0e3a-4e0c-908d-6f44e80f9400"),
+			resource.TestCheckResourceAttr(resourceName, "tenant_id", "fddf23ae-0e3a-4e0c-908d-6f44e80f9401"),
+			resource.TestCheckResourceAttr(resourceName, "client_secret", "test-secret3"),
+		))
 }


### PR DESCRIPTION
Migrate the posture_integration resource to the plugin framework.

Test plan: run all tests with acceptance testing enabled, e.g. `make testacc`

Updates tailscale/corp#37243
