### PR TITLE
resource_webhook: handle null provider

### DIFF
--- a/tailscale/resource_webhook.go
+++ b/tailscale/resource_webhook.go
@@ -191,7 +191,7 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	state.EndpointURL = types.StringValue(webhook.EndpointURL)
-	state.ProviderType = types.StringValue(string(webhook.ProviderType))
+	state.ProviderType = StringValueNullIfEmpty(string(webhook.ProviderType))
 
 	subscriptions, diags := types.SetValueFrom(ctx, types.StringType, webhook.Subscriptions)
 	resp.Diagnostics.Append(diags...)

--- a/tailscale/resource_webhook_test.go
+++ b/tailscale/resource_webhook_test.go
@@ -32,6 +32,12 @@ const testWebhookUpdate = `
 		subscriptions = ["nodeCreated", "userSuspended", "userRoleUpdated"]
 	}`
 
+const testWebhookNoProvider = `
+	resource "tailscale_webhook" "test_webhook" {
+		endpoint_url = "https://example.com/endpoint"
+		subscriptions = ["userNeedsApproval", "nodeCreated"]
+	}`
+
 func TestProvider_TailscaleWebhook(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -140,4 +146,30 @@ func TestAccTailscaleWebhook(t *testing.T) {
 	//
 	// See https://developer.hashicorp.com/terraform/plugin/framework/migrating/testing#terraform-data-resource-example
 	checkResourceIsUnchangedInPluginFramework(t, testWebhookCreate, createCheck)
+}
+
+// TestAccTailscaleWebhookOptionalFields checks that we can round-trip set /
+// update / read the provider field, which is an optional string, without
+// getting complaints that it is changing between null and StringVal("").
+func TestAccTailscaleWebhookOptionalFields(t *testing.T) {
+	const resourceName = "tailscale_webhook.test_webhook"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProviderFactories(t),
+		CheckDestroy: checkResourceDestroyed(resourceName, func(client *tailscale.Client, rs *terraform.ResourceState) error {
+			_, err := client.Webhooks().Get(context.Background(), rs.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("webhook %q still exists on server", resourceName)
+			}
+			return nil
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: testWebhookNoProvider,
+			},
+		},
+	})
+
+	checkResourceIsUnchangedInPluginFramework(t, testWebhookNoProvider, nil)
 }


### PR DESCRIPTION
(Stacked on #707 so I can re-use `StringValueNullIfEmpty` from there)

I added a test to check that not supplying a provider works, but it failed because an empty string comes back from the client, and the state has a null instead.

Updated the provider to coerce an empty string coming back from the client to a null value.

Test plan: run all acceptance tests. Alternatively, create a terraform file that creates a webhook without setting the `provider` field and ensure that it does not still show a diff after a plan.
