### PR TITLE
resource_device_authorization: return on create error

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -114,6 +114,7 @@ func (d deviceAuthorizationResource) Create(ctx context.Context, req resource.Cr
 			"Failed to authorize device",
 			"Could not authorize device with ID "+deviceID+": "+err.Error(),
 		)
+		return
 	}
 
 	plan.ID = types.StringValue(deviceID)


### PR DESCRIPTION
Return if device authorization fails after setting the error to avoid that anything gets written to state.

Updates tailscale/corp#37231
