### PR TITLE
tailscale: consolidate device error messages

### DIFF
--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -79,8 +79,8 @@ func (d deviceAuthorizationResource) Read(ctx context.Context, req resource.Read
 	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to fetch device",
-			"Could not read device authorization for device with ID "+deviceID+": "+err.Error(),
+			"Failed to fetch device authorization",
+			"Failed to fetch authorization for device with with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -111,8 +111,8 @@ func (d deviceAuthorizationResource) Create(ctx context.Context, req resource.Cr
 
 	if err := d.Client.Devices().SetAuthorized(ctx, deviceID, authorized); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to authorize device",
-			"Could not authorize device with ID "+deviceID+": "+err.Error(),
+			"Failed to update device authorization",
+			"Failed to update authorization for device with ID "+deviceID+": "+err.Error(),
 		)
 	}
 
@@ -135,8 +135,8 @@ func (d deviceAuthorizationResource) Update(ctx context.Context, req resource.Up
 
 	if err := d.Client.Devices().SetAuthorized(ctx, deviceID, authorized); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to authorize device",
-			"Could not authorize device with ID"+deviceID+": "+err.Error(),
+			"Failed to update device authorization",
+			"Failed to update authorization for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -73,8 +73,8 @@ func (d deviceKeyResource) Create(ctx context.Context, req resource.CreateReques
 
 	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to create device key",
-			"Could not create device key: "+err.Error(),
+			"Failed to update device key",
+			"Failed to update key for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -97,8 +97,8 @@ func (d deviceKeyResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to delete device key",
-			"Could not delete device key: "+err.Error(),
+			"Failed to update device key",
+			"Failed to update key for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -117,8 +117,8 @@ func (d deviceKeyResource) Read(ctx context.Context, req resource.ReadRequest, r
 	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to fetch devices",
-			"Could not read device key for device with ID "+deviceID+": "+err.Error(),
+			"Failed to fetch device key",
+			"Failed to fetch key for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -154,7 +154,7 @@ func (d deviceKeyResource) Update(ctx context.Context, req resource.UpdateReques
 	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to update device key",
-			"Could not update device key: "+err.Error(),
+			"Failed to update key for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -102,7 +102,7 @@ func (d deviceSubnetRoutesResource) Read(ctx context.Context, req resource.ReadR
 
 		resp.Diagnostics.AddError(
 			"Failed to fetch device subnet routes",
-			"Could not read subnet routes for device with ID "+deviceID+": "+err.Error(),
+			"Failed to fetch subnet routes for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -138,8 +138,8 @@ func (d deviceSubnetRoutesResource) Create(ctx context.Context, req resource.Cre
 
 	if err := d.Client.Devices().SetSubnetRoutes(ctx, deviceID, subnetRoutes); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to set device subnet routes",
-			"Could not set subnet routes for device with ID "+deviceID+": "+err.Error(),
+			"Failed to update device subnet routes",
+			"Failed to update subnet routes for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -169,8 +169,8 @@ func (d deviceSubnetRoutesResource) Update(ctx context.Context, req resource.Upd
 
 	if err := d.Client.Devices().SetSubnetRoutes(ctx, deviceID, subnetRoutes); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to set device subnet routes",
-			"Could not set subnet routes for device with ID "+deviceID+": "+err.Error(),
+			"Failed to update device subnet routes",
+			"Failed to update subnet routes for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -192,7 +192,7 @@ func (d deviceSubnetRoutesResource) Delete(ctx context.Context, req resource.Del
 	if err := d.Client.Devices().SetSubnetRoutes(ctx, deviceID, []string{}); err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to delete device subnet routes",
-			"Could not delete subnet routes for device with ID "+deviceID+": "+err.Error(),
+			"Failed to delete subnet routes for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -78,8 +78,8 @@ func (d deviceTagsResource) Read(ctx context.Context, req resource.ReadRequest, 
 	device, err := d.Client.Devices().Get(ctx, deviceID)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to fetch device",
-			"Could not read device tags for device with ID "+deviceID+": "+err.Error(),
+			"Failed to fetch device tags",
+			"Failed to fetch device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -120,8 +120,8 @@ func (d deviceTagsResource) Create(ctx context.Context, req resource.CreateReque
 
 	if err := d.Client.Devices().SetTags(ctx, deviceID, tags); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to set device tags",
-			"Could not set tags for device with ID "+deviceID+": "+err.Error(),
+			"Failed to update device tags",
+			"Failed to update tags for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -149,8 +149,8 @@ func (d deviceTagsResource) Update(ctx context.Context, req resource.UpdateReque
 
 	if err := d.Client.Devices().SetTags(ctx, deviceID, tags); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to set device tags",
-			"Could not set tags for device with ID "+deviceID+": "+err.Error(),
+			"Failed to update device tags",
+			"Failed to update tags for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}
@@ -182,8 +182,8 @@ func (d deviceTagsResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	if err := d.Client.Devices().SetTags(ctx, deviceID, []string{}); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to set device tags",
-			"Could not delete tags: "+err.Error(),
+			"Failed to delete device tags",
+			"Failed to delete tags for device with ID "+deviceID+": "+err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
This consolidates the error messages for the device attribute resources to follow a consistent pattern.

In the future, there might be benefit in creating wrapper methods for `d.Client.Devices().Get(ctx, deviceID)` plus the error catching and appending the error message to diagnostics. I've not done this in order to make it easier to review the error messages and assess the pattern they're following in isolation. Also, at least for the moment, the duplication might not be so tremendous as to warrant it.

**Read**
- summary: "Failed to fetch device $ATTRIBUTE"
- detail: "Failed to fetch $ATTRIBUTE for device with ID $DEVICE_ID: $ERROR"

**Create and Update**
- summary: "Failed to update device $ATTRIBUTE"
- detail: "Failed to update $ATTRIBUTE for device with ID $DEVICE_ID: $ERROR"

**Delete for tags and subnet routes (where it’s definitely appropriate to say “delete” because we go from non-empty to an empty slice)**
- summary: "Failed to delete device $ATTRIBUTE"
- detail: "Failed to delete $ATTRIBUTE for device with ID $DEVICE_ID: $ERROR"

**Delete for authorization and key**
- summary: "Failed to update device $ATTRIBUTE"
- detail: "Failed to update $ATTRIBUTE for device with ID $DEVICE_ID: $ERROR"

Updates tailscale/corp#40809
