### PR TITLE
all: extract validators; add retryValidator tests; add invalid data_source_device config tests

### DIFF
--- a/tailscale/data_source_4via6.go
+++ b/tailscale/data_source_4via6.go
@@ -5,10 +5,8 @@ package tailscale
 
 import (
 	"context"
-	"net"
 	"net/netip"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -101,31 +99,4 @@ func (d dataSource4via6) Read(ctx context.Context, req datasource.ReadRequest, r
 	data.IPv6 = types.StringValue(mapped)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-// cidrValidator is a [validator.String] for CIDR addresses.
-type cidrValidator struct{}
-
-func (v cidrValidator) Description(_ context.Context) string {
-	return "value must be a CIDR address."
-}
-
-func (v cidrValidator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
-}
-
-func (v cidrValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
-		return
-	}
-
-	value := req.ConfigValue.ValueString()
-	_, _, err := net.ParseCIDR(value)
-	if err != nil {
-		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-			req.Path,
-			v.Description(ctx),
-			req.ConfigValue.ValueString(),
-		))
-	}
 }

--- a/tailscale/data_source_4via6_test.go
+++ b/tailscale/data_source_4via6_test.go
@@ -10,9 +10,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"tailscale.com/net/tsaddr"
@@ -112,54 +109,4 @@ func check4Via6Result(n string) resource.TestCheckFunc {
 // and the plugin framework.
 func TestAccTailscale4via6_UpgradeToPluginFramework(t *testing.T) {
 	checkDataSourceIsUnchangedInPluginFramework(t, testDataSource4Via6)
-}
-
-func TestCIDRValidator(t *testing.T) {
-	tests := []struct {
-		name    string
-		cidr    string
-		wantErr bool
-	}{
-		{
-			name: "valid-cidr",
-			cidr: "1.2.3.4/28",
-		},
-		{
-			name:    "invalid-value",
-			cidr:    "1234567890",
-			wantErr: true,
-		},
-		{
-			name:    "no-slash",
-			cidr:    "1.2.3.4",
-			wantErr: true,
-		},
-		{
-			name:    "empty",
-			cidr:    "",
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		cidrValidator := cidrValidator{}
-
-		req := validator.StringRequest{
-			ConfigValue: types.StringValue(tt.cidr),
-		}
-
-		resp := validator.StringResponse{
-			Diagnostics: diag.Diagnostics{},
-		}
-
-		t.Run(tt.name, func(t *testing.T) {
-			cidrValidator.ValidateString(t.Context(), req, &resp)
-
-			hasError := resp.Diagnostics.HasError()
-			if hasError && !tt.wantErr {
-				t.Errorf("got unexpected error from validator: %v", resp.Diagnostics.Errors())
-			} else if !hasError && tt.wantErr {
-				t.Errorf("validator passed, expected failure")
-			}
-		})
-	}
 }

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -78,31 +78,6 @@ func (d singleDeviceDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 	}
 }
 
-type retryDeadlineValidator struct {
-}
-
-func (r retryDeadlineValidator) Description(_ context.Context) string {
-	return "Validates that the value is a duration greater than 1s."
-}
-
-func (r retryDeadlineValidator) MarkdownDescription(ctx context.Context) string {
-	return r.Description(ctx)
-}
-
-func (r retryDeadlineValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsNull() {
-		return
-	}
-	waitFor, err := time.ParseDuration(req.ConfigValue.ValueString())
-	switch {
-	case err != nil:
-		resp.Diagnostics.AddAttributeError(req.Path, "failed to parse wait_for", "not a duration")
-	case waitFor <= time.Second:
-		resp.Diagnostics.AddAttributeError(req.Path, "failed to parse wait_for", "wait_for must be greater than 1 second")
-	default:
-	}
-}
-
 // Read fetches the data from the Tailscale API.
 func (d singleDeviceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var device singleDeviceDataSourceModel

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -46,21 +46,12 @@ func (d singleDeviceDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			Description: "The full name of the device (e.g. `hostname.domain.ts.net`)",
 			Optional:    true,
 			Validators: []validator.String{
-				stringvalidator.ExactlyOneOf(path.Expressions{
-					path.MatchRoot("name"),
-					path.MatchRoot("hostname"),
-				}...),
+				stringvalidator.ExactlyOneOf(path.MatchRoot("name"), path.MatchRoot("hostname")),
 			},
 		},
 		"hostname": schema.StringAttribute{
 			Description: "The short hostname of the device",
 			Optional:    true,
-			Validators: []validator.String{
-				stringvalidator.ExactlyOneOf(path.Expressions{
-					path.MatchRoot("name"),
-					path.MatchRoot("hostname"),
-				}...),
-			},
 		},
 		"wait_for": schema.StringAttribute{
 			Description: "If specified, the provider will make multiple attempts to obtain the data source until the wait_for duration is reached. Retries are made every second so this value should be greater than 1s",

--- a/tailscale/data_source_device_test.go
+++ b/tailscale/data_source_device_test.go
@@ -247,6 +247,59 @@ func TestRetryWithDeadline_NoRetryWhenWaitForIsZero(t *testing.T) {
 	}
 }
 
+func TestProvider_DataSourceDevice_InvalidConfig(t *testing.T) {
+	testCases := []expectedErrorTestCase{
+		{
+			Name:        "no-fields",
+			Config:      `data "tailscale_device" "example" {}`,
+			ExpectError: regexp.MustCompile(`No attribute specified when one \(and only one\) of \[name,hostname\] is required`),
+		},
+		{
+			Name: "too-many-fields",
+			Config: `
+					data "tailscale_device" "example" {
+						name     = "hostname.domain.ts.net"
+						hostname = "hostname"
+					}
+				`,
+			ExpectError: regexp.MustCompile(`2 attributes specified when one \(and only one\) of \[name,hostname\] is required`),
+		},
+
+		{
+			Name: "invalid-wait-for",
+			Config: `
+				data "tailscale_device" "example" {
+					name     = "hostname.domain.ts.net"
+					wait_for = "century"
+				}
+			`,
+			ExpectError: regexp.MustCompile(`Attribute wait_for unable to parse value as a duration, got: century`),
+		},
+		{
+			Name: "wait-for-1s",
+			Config: `
+				data "tailscale_device" "example" {
+					name     = "hostname.domain.ts.net"
+					wait_for = "1s"
+				}
+			`,
+			ExpectError: regexp.MustCompile(`Attribute wait_for duration must be greater than 1 second, got: 1s`),
+		},
+		{
+			Name: "wait-for-less-than-1s",
+			Config: `
+				data "tailscale_device" "example" {
+					name     = "hostname.domain.ts.net"
+					wait_for = "1ms"
+				}
+			`,
+			ExpectError: regexp.MustCompile(`Attribute wait_for duration must be greater than 1 second, got: 1ms`),
+		},
+	}
+
+	runExpectedErrorTests(t, testCases)
+}
+
 // deviceToMap converts the given device into a map representing the device as a
 // resource in Terraform. This omits the "id" which is expected to be set
 // using [schema.ResourceData.SetId].

--- a/tailscale/plan_modifiers.go
+++ b/tailscale/plan_modifiers.go
@@ -17,9 +17,8 @@ var (
 	_ planmodifier.String = PreserveEmptyStringAsNull{}
 )
 
-// jsonSemanticDiffModifier is a plan modifier that will treat strings as
-// equivalent if they correspond to the same JSON value, and differ only
-// in whitespace.
+// jsonSemanticDiffModifier treats strings as equivalent if they correspond
+// to the same JSON value, and differ only in whitespace.
 type jsonSemanticDiffModifier struct{}
 
 func (m jsonSemanticDiffModifier) Description(_ context.Context) string {

--- a/tailscale/plan_modifiers_test.go
+++ b/tailscale/plan_modifiers_test.go
@@ -4,7 +4,6 @@
 package tailscale
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -125,8 +124,6 @@ type stringPlanModifierTestCase struct {
 // runStringPlanModifierTests goes through the test cases, applies the
 // plan modifier, and checks if the PlanValue matches the expected.
 func runStringPlanModifierTests(t *testing.T, modifier planmodifier.String, testCases []stringPlanModifierTestCase) {
-	ctx := context.Background()
-
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			// StateValue is the value currently stored in the state,
@@ -145,7 +142,7 @@ func runStringPlanModifierTests(t *testing.T, modifier planmodifier.String, test
 				PlanValue: req.PlanValue,
 			}
 
-			modifier.PlanModifyString(ctx, req, &resp)
+			modifier.PlanModifyString(t.Context(), req, &resp)
 
 			if resp.PlanValue != tt.expectedPlan {
 				t.Errorf("plan value is incorrect: got %s, want %s", resp.PlanValue, tt.expectedPlan)

--- a/tailscale/plan_modifiers_test.go
+++ b/tailscale/plan_modifiers_test.go
@@ -49,11 +49,21 @@ func TestJsonSemanticDiffModifier(t *testing.T) {
 			config:       types.StringValue("<xml>this isn't JSON either</xml>"),
 			expectedPlan: types.StringValue("<xml>this isn't JSON either</xml>"),
 		},
+		{
+			name:         "config-null",
+			state:        types.StringValue(`{"sides": 8, "colour": "red"}`),
+			config:       types.StringNull(),
+			expectedPlan: types.StringNull(),
+		},
+		{
+			name:         "config-unknown",
+			state:        types.StringValue(`{"sides": 1, "colour": "pink"}`),
+			config:       types.StringUnknown(),
+			expectedPlan: types.StringUnknown(),
+		},
 	}
 
-	for _, tt := range testCases {
-		runStringPlanModifierTest(t, jsonSemanticDiffModifier{}, tt)
-	}
+	runStringPlanModifierTests(t, jsonSemanticDiffModifier{}, testCases)
 }
 
 func TestPreserveEmptyStringAsNull(t *testing.T) {
@@ -94,11 +104,15 @@ func TestPreserveEmptyStringAsNull(t *testing.T) {
 			config:       types.StringNull(),
 			expectedPlan: types.StringValue(""),
 		},
+		{
+			name:         "null-in-state-empty-string-in-plan",
+			state:        types.StringNull(),
+			config:       types.StringValue(""),
+			expectedPlan: types.StringValue(""),
+		},
 	}
 
-	for _, tt := range testCases {
-		runStringPlanModifierTest(t, PreserveEmptyStringAsNull{}, tt)
-	}
+	runStringPlanModifierTests(t, PreserveEmptyStringAsNull{}, testCases)
 }
 
 type stringPlanModifierTestCase struct {
@@ -108,32 +122,34 @@ type stringPlanModifierTestCase struct {
 	expectedPlan types.String
 }
 
-// runStringPlanModifierTest passes two strings as the plan/state values,
-// and checks if the modifier correctly reports a diff or not.
-func runStringPlanModifierTest(t *testing.T, modifier planmodifier.String, tt stringPlanModifierTestCase) {
+// runStringPlanModifierTests goes through the test cases, applies the
+// plan modifier, and checks if the PlanValue matches the expected.
+func runStringPlanModifierTests(t *testing.T, modifier planmodifier.String, testCases []stringPlanModifierTestCase) {
 	ctx := context.Background()
 
-	t.Run(tt.name, func(t *testing.T) {
-		// StateValue is the value currently stored in the state,
-		// ConfigValue is the exact value written by the user in their configuration,
-		// PlanValue is the value Terraform proposes to save
-		//
-		// Initially the PlanValue is the same as the ConfigValue, and we check
-		// if it's been updated correctly (or left as-is) after we've applied
-		// the plan modifier.
-		req := planmodifier.StringRequest{
-			StateValue:  tt.state,
-			ConfigValue: tt.config,
-			PlanValue:   tt.config,
-		}
-		resp := planmodifier.StringResponse{
-			PlanValue: req.PlanValue,
-		}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// StateValue is the value currently stored in the state,
+			// ConfigValue is the exact value written by the user in their configuration,
+			// PlanValue is the value Terraform proposes to save
+			//
+			// Initially the PlanValue is the same as the ConfigValue, and we check
+			// if it's been updated correctly (or left as-is) after we've applied
+			// the plan modifier.
+			req := planmodifier.StringRequest{
+				StateValue:  tt.state,
+				ConfigValue: tt.config,
+				PlanValue:   tt.config,
+			}
+			resp := planmodifier.StringResponse{
+				PlanValue: req.PlanValue,
+			}
 
-		modifier.PlanModifyString(ctx, req, &resp)
+			modifier.PlanModifyString(ctx, req, &resp)
 
-		if resp.PlanValue != tt.expectedPlan {
-			t.Errorf("plan value is incorrect: got %s, want %s", resp.PlanValue, tt.expectedPlan)
-		}
-	})
+			if resp.PlanValue != tt.expectedPlan {
+				t.Errorf("plan value is incorrect: got %s, want %s", resp.PlanValue, tt.expectedPlan)
+			}
+		})
+	}
 }

--- a/tailscale/validator_test.go
+++ b/tailscale/validator_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestCIDRValidator(t *testing.T) {
+	testCases := []stringValidatorTestCase{
+		{
+			name:   "valid-cidr",
+			config: types.StringValue("1.2.3.4/28"),
+		},
+		{
+			name:    "invalid-value",
+			config:  types.StringValue("1234567890"),
+			wantErr: true,
+		},
+		{
+			name:    "no-slash",
+			config:  types.StringValue("1.2.3.4"),
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			config:  types.StringValue(""),
+			wantErr: true,
+		},
+	}
+
+	runStringValidatorTests(t, cidrValidator{}, testCases)
+}
+
+func TestRetryDeadlineValidator(t *testing.T) {
+	testCases := []stringValidatorTestCase{
+		{
+			name:   "valid-duration",
+			config: types.StringValue("5s"),
+		},
+		{
+			name:    "invalid-duration",
+			config:  types.StringValue("abc"),
+			wantErr: true,
+		},
+		{
+			name:    "duration-1s",
+			config:  types.StringValue("1s"),
+			wantErr: true,
+		},
+		{
+			name:    "duration-lt-1s",
+			config:  types.StringValue("1ms"),
+			wantErr: true,
+		},
+	}
+
+	runStringValidatorTests(t, retryDeadlineValidator{}, testCases)
+}
+
+type stringValidatorTestCase struct {
+	name    string
+	config  types.String
+	wantErr bool
+}
+
+// runStringValidatorTests goes through the test cases, applies the
+// validator, and checks if the string is passed/errored as expected.
+func runStringValidatorTests(t *testing.T, stringValidator validator.String, testCases []stringValidatorTestCase) {
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				ConfigValue: tt.config,
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			t.Run(tt.name, func(t *testing.T) {
+				stringValidator.ValidateString(t.Context(), req, &resp)
+
+				hasError := resp.Diagnostics.HasError()
+				if hasError && !tt.wantErr {
+					t.Errorf("got unexpected error from validator: %v", resp.Diagnostics.Errors())
+				} else if !hasError && tt.wantErr {
+					t.Errorf("validator passed, expected failure")
+				}
+			})
+		})
+	}
+}

--- a/tailscale/validators.go
+++ b/tailscale/validators.go
@@ -1,0 +1,79 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var (
+	_ validator.String = cidrValidator{}
+	_ validator.String = retryDeadlineValidator{}
+)
+
+// cidrValidator is a [validator.String] for CIDR addresses.
+type cidrValidator struct{}
+
+func (v cidrValidator) Description(_ context.Context) string {
+	return "value must be a CIDR address."
+}
+
+func (v cidrValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v cidrValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+	_, _, err := net.ParseCIDR(value)
+	if err != nil {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			req.Path,
+			v.Description(ctx),
+			req.ConfigValue.ValueString(),
+		))
+	}
+}
+
+// retryDeadlineValdiator is a [validator.String] that checks whether a string can be
+// parsed as a duration greater than 1s.
+type retryDeadlineValidator struct{}
+
+func (r retryDeadlineValidator) Description(_ context.Context) string {
+	return "Validates that the value is a duration greater than 1s."
+}
+
+func (r retryDeadlineValidator) MarkdownDescription(ctx context.Context) string {
+	return r.Description(ctx)
+}
+
+func (r retryDeadlineValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() {
+		return
+	}
+	waitFor, err := time.ParseDuration(req.ConfigValue.ValueString())
+	switch {
+	case err != nil:
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			req.Path,
+			"unable to parse value as a duration",
+			req.ConfigValue.ValueString(),
+		))
+	case waitFor <= time.Second:
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			req.Path,
+			"duration must be greater than 1 second",
+			req.ConfigValue.ValueString(),
+		))
+	default:
+	}
+}


### PR DESCRIPTION
For https://github.com/tailscale/corp/issues/37228 I need to write a custom plan modifier and a custom validator, and I'll want to write some unit tests.

This extracts the existing custom validators into `validators.go` and adds a test harness; it also adds some unit tests for where they're used in `data_source_device`. Plus some minor tidies in the plan modifier tests.