### PR TITLE
resource_service: migrate to plugin framework

### DIFF
--- a/tailscale/data_source_service.go
+++ b/tailscale/data_source_service.go
@@ -87,20 +87,10 @@ func (d dataSourceService) Read(ctx context.Context, req datasource.ReadRequest,
 
 	data.ID = types.StringValue(svc.Name)
 	data.Name = types.StringValue(svc.Name)
-
-	addrs, diags := types.ListValueFrom(ctx, types.StringType, svc.Addrs)
-	resp.Diagnostics.Append(diags...)
-	data.Addrs = addrs
-
+	data.Addrs = ListOfStringValue(ctx, svc.Addrs, &resp.Diagnostics)
 	data.Comment = types.StringValue(svc.Comment)
-
-	ports, diags := types.ListValueFrom(ctx, types.StringType, svc.Ports)
-	resp.Diagnostics.Append(diags...)
-	data.Ports = ports
-
-	tags, diags := types.SetValueFrom(ctx, types.StringType, svc.Tags)
-	resp.Diagnostics.Append(diags...)
-	data.Tags = tags
+	data.Ports = ListOfStringValue(ctx, svc.Ports, &resp.Diagnostics)
+	data.Tags = SetOfStringValue(ctx, svc.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -179,6 +179,7 @@ func (p *tailscaleProvider) Resources(_ context.Context) []func() resource.Resou
 		NewDNSSplitNameserversResource,
 		NewLogstreamConfigurationResource,
 		NewPostureIntegrationResource,
+		NewServiceResource,
 		NewWebhookResource,
 	}
 }

--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -12,10 +12,12 @@ import (
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"tailscale.com/client/tailscale/v2"
 )
 
@@ -247,6 +249,20 @@ func createTailscaleClient(baseURL *url.URL, userAgent string, tailnet string, a
 			Tailnet:   tailnet,
 		}
 	}
+}
+
+// ListOfStringValue returns a [types.ListValue] of strings.
+func ListOfStringValue(ctx context.Context, value []string, diags *diag.Diagnostics) basetypes.ListValue {
+	v, d := types.ListValueFrom(ctx, types.StringType, value)
+	diags.Append(d...)
+	return v
+}
+
+// SetOfStringValue returns a [types.SetValue] of strings.
+func SetOfStringValue(ctx context.Context, value any, diags *diag.Diagnostics) basetypes.SetValue {
+	v, d := types.SetValueFrom(ctx, types.StringType, value)
+	diags.Append(d...)
+	return v
 }
 
 // StringValueNullIfEmpty returns a StringValue of the given input string, or a

--- a/tailscale/provider_sdk.go
+++ b/tailscale/provider_sdk.go
@@ -102,7 +102,6 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"tailscale_oauth_client":       resourceOAuthClient(),
 			"tailscale_tailnet_settings":   resourceTailnetSettings(),
 			"tailscale_federated_identity": resourceFederatedIdentity(),
-			"tailscale_service":            resourceService(),
 		},
 	}
 

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -107,13 +107,11 @@ func (d deviceSubnetRoutesResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	routes, diags := types.SetValueFrom(ctx, types.StringType, deviceRoutes.Enabled)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
+	state.Routes = SetOfStringValue(ctx, deviceRoutes.Enabled, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	state.Routes = routes
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -98,12 +98,11 @@ func (d deviceTagsResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	state.DeviceID = types.StringValue(canonicalDeviceID)
-	tags, diags := types.SetValueFrom(ctx, types.StringType, device.Tags)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
+	state.Tags = SetOfStringValue(ctx, device.Tags, &resp.Diagnostics)
+
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/tailscale/resource_dns_configuration.go
+++ b/tailscale/resource_dns_configuration.go
@@ -184,11 +184,7 @@ func (r *dnsConfigurationResource) Read(ctx context.Context, req resource.ReadRe
 		})
 	}
 	state.SplitDNS = splitDNS
-
-	searchPaths, diags := types.ListValueFrom(ctx, types.StringType, remote.SearchPaths)
-	resp.Diagnostics.Append(diags...)
-	state.SearchPaths = searchPaths
-
+	state.SearchPaths = ListOfStringValue(ctx, remote.SearchPaths, &resp.Diagnostics)
 	state.OverrideLocalDNS = types.BoolValue(remote.Preferences.OverrideLocalDNS)
 	state.MagicDNS = types.BoolValue(remote.Preferences.MagicDNS)
 

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -81,13 +81,11 @@ func (r *dnsNameserversResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	nsSet, diags := types.ListValueFrom(ctx, types.StringType, servers)
-	resp.Diagnostics.Append(diags...)
+	state.Nameservers = ListOfStringValue(ctx, servers, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	state.Nameservers = nsSet
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -73,13 +73,11 @@ func (r *dnsSearchPathsResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	searchPaths, diags := types.ListValueFrom(ctx, types.StringType, paths)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
+	state.SearchPaths = ListOfStringValue(ctx, paths, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	state.SearchPaths = searchPaths
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -88,14 +88,12 @@ func (r *dnsSplitNameserversResource) Read(ctx context.Context, req resource.Rea
 
 	domain := state.Domain.ValueString()
 	nameservers := splitDNS[domain]
+	state.Nameservers = SetOfStringValue(ctx, nameservers, &resp.Diagnostics)
 
-	nsSet, diags := types.SetValueFrom(ctx, types.StringType, nameservers)
-	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	state.Nameservers = nsSet
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/tailscale/resource_logstream_configuration.go
+++ b/tailscale/resource_logstream_configuration.go
@@ -256,10 +256,7 @@ func (d *logstreamConfigurationResourceModel) updateFields(ctx context.Context, 
 	d.S3RoleARN = StringValueNullIfEmpty(config.S3RoleARN)
 	d.S3ExternalID = StringValueNullIfEmpty(config.S3ExternalID)
 
-	gcsScopes, scopeDiags := types.SetValueFrom(ctx, types.StringType, config.GCSScopes)
-	diags.Append(scopeDiags...)
-	d.GCSScopes = gcsScopes
-
+	d.GCSScopes = SetOfStringValue(ctx, config.GCSScopes, diags)
 	d.GCSCredentials = StringValueNullIfEmpty(config.GCSCredentials)
 	d.GCSKeyPrefix = StringValueNullIfEmpty(config.GCSKeyPrefix)
 	d.GCSBucket = StringValueNullIfEmpty(config.GCSBucket)

--- a/tailscale/resource_service.go
+++ b/tailscale/resource_service.go
@@ -127,9 +127,7 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	addrs, d := types.ListValueFrom(ctx, types.StringType, createdSvc.Addrs)
-	resp.Diagnostics.Append(d...)
-	plan.Addrs = addrs
+	plan.Addrs = ListOfStringValue(ctx, createdSvc.Addrs, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -153,18 +151,9 @@ func (r *serviceResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	state.Name = types.StringValue(svc.Name)
 	state.Comment = types.StringValue(svc.Comment)
-
-	addrs, d := types.ListValueFrom(ctx, types.StringType, svc.Addrs)
-	resp.Diagnostics.Append(d...)
-	state.Addrs = addrs
-
-	ports, d := types.SetValueFrom(ctx, types.StringType, svc.Ports)
-	resp.Diagnostics.Append(d...)
-	state.Ports = ports
-
-	tags, d := types.SetValueFrom(ctx, types.StringType, svc.Tags)
-	resp.Diagnostics.Append(d...)
-	state.Tags = tags
+	state.Addrs = ListOfStringValue(ctx, svc.Addrs, &resp.Diagnostics)
+	state.Ports = SetOfStringValue(ctx, svc.Ports, &resp.Diagnostics)
+	state.Tags = SetOfStringValue(ctx, svc.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/tailscale/resource_service.go
+++ b/tailscale/resource_service.go
@@ -5,155 +5,214 @@ package tailscale
 
 import (
 	"context"
+	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"tailscale.com/client/tailscale/v2"
 )
 
-func resourceService() *schema.Resource {
-	return &schema.Resource{
-		Description:   "The Service resource allows you to manage Tailscale Services in your Tailscale network. Services let you publish internal resources (like databases or web servers) as named resources in your tailnet. Services provide a stable MagicDNS name, a Tailscale virtual IP address pair, can be served by multiple nodes, and are valid access control destinations. See https://tailscale.com/docs/features/tailscale-services) for more information.",
-		ReadContext:   resourceServiceRead,
-		CreateContext: resourceServiceCreate,
-		UpdateContext: resourceServiceUpdate,
-		DeleteContext: resourceServiceDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
+var (
+	_ resource.Resource                = &serviceResource{}
+	_ resource.ResourceWithImportState = &webhookResource{}
+)
+
+type serviceResourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Name    types.String `tfsdk:"name"`
+	Addrs   types.List   `tfsdk:"addrs"`
+	Comment types.String `tfsdk:"comment"`
+	Ports   types.Set    `tfsdk:"ports"`
+	Tags    types.Set    `tfsdk:"tags"`
+}
+
+// NewServiceResource returns a new service resource.
+func NewServiceResource() resource.Resource {
+	return &serviceResource{}
+}
+
+type serviceResource struct {
+	ResourceBase
+}
+
+// Metadata defines the resource name as it appears in Terraform configurations.
+func (r *serviceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service"
+}
+
+// Schema defines a schema describing what fields can be defined in the resource.
+func (r *serviceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "The Service resource allows you to manage Tailscale Services in your Tailscale network. Services let you publish internal resources (like databases or web servers) as named resources in your tailnet. Services provide a stable MagicDNS name, a Tailscale virtual IP address pair, can be served by multiple nodes, and are valid access control destinations. See https://tailscale.com/docs/features/tailscale-services) for more information.",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
 				Description: "The name of the Service. Must begin with `svc:`.",
 				Required:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^svc:.*"), "must start with svc:"),
+				},
 			},
-			"id": {
-				Type: schema.TypeString,
+			"id": schema.StringAttribute{
 				// The ID must be predictable to support importing existing
 				// Services, e.g. 'terraform import tailscale_service.my_service
 				// svc:my-service'. The Service name will be a known value and
 				// is the ID used by the API anyway.
 				Description: "The Service name, e.g. 'svc:my-service'.",
 				Computed:    true,
-			},
-			"addrs": {
-				Type:        schema.TypeList,
-				Description: "The IP addresses assigned to the Service.",
-				Computed:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"comment": {
-				Type:        schema.TypeString,
+			"addrs": schema.ListAttribute{
+				Description: "The IP addresses assigned to the Service.",
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"comment": schema.StringAttribute{
 				Description: "An optional comment describing the Service.",
 				Optional:    true,
 			},
-			"ports": {
-				Type:        schema.TypeSet,
+			"ports": schema.SetAttribute{
 				Description: "A list of protocol:port pairs to be exposed by the Service. The only supported protocol is \"tcp\" at this time. \"do-not-validate\" can be used to skip validation.",
 				Required:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				ElementType: types.StringType,
 			},
-			"tags": {
-				Type:        schema.TypeSet,
+			"tags": schema.SetAttribute{
 				Description: "The ACL tags applied to the Service.",
 				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				ElementType: types.StringType,
 			},
 		},
 	}
 }
 
-func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
-
-	svc := buildServiceFromResource(d)
-	if err := client.VIPServices().CreateOrUpdate(ctx, svc); err != nil {
-		return diagnosticsError(err, "Failed to create Service")
+func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan serviceResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	d.SetId(svc.Name)
-	return resourceServiceRead(ctx, d, m)
+	svc := r.buildServiceFromResource(ctx, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.Client.VIPServices().CreateOrUpdate(ctx, svc); err != nil {
+		resp.Diagnostics.AddError("Failed to create Service", err.Error())
+		return
+	}
+
+	plan.ID = plan.Name
+
+	// Re-fetch to get the 'addrs' which are computed by the API
+	createdSvc, err := r.Client.VIPServices().Get(ctx, plan.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to fetch service for IPs", err.Error())
+		return
+	}
+
+	addrs, d := types.ListValueFrom(ctx, types.StringType, createdSvc.Addrs)
+	resp.Diagnostics.Append(d...)
+	plan.Addrs = addrs
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+func (r *serviceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state serviceResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	svc, err := client.VIPServices().Get(ctx, d.Id())
+	svc, err := r.Client.VIPServices().Get(ctx, state.ID.ValueString())
 	if err != nil {
 		if tailscale.IsNotFound(err) {
-			d.SetId("")
-			return nil
+			resp.State.RemoveResource(ctx)
+			return
 		}
-		return diagnosticsError(err, "Failed to fetch Service %q", d.Id())
+		resp.Diagnostics.AddError("Failed to fetch Service", err.Error())
+		return
 	}
 
-	return setProperties(d, map[string]any{
-		"name":    svc.Name,
-		"addrs":   svc.Addrs,
-		"comment": svc.Comment,
-		"ports":   svc.Ports,
-		"tags":    svc.Tags,
-	})
+	state.Name = types.StringValue(svc.Name)
+	state.Comment = types.StringValue(svc.Comment)
+
+	addrs, d := types.ListValueFrom(ctx, types.StringType, svc.Addrs)
+	resp.Diagnostics.Append(d...)
+	state.Addrs = addrs
+
+	ports, d := types.SetValueFrom(ctx, types.StringType, svc.Ports)
+	resp.Diagnostics.Append(d...)
+	state.Ports = ports
+
+	tags, d := types.SetValueFrom(ctx, types.StringType, svc.Tags)
+	resp.Diagnostics.Append(d...)
+	state.Tags = tags
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
-
-	svc := buildServiceFromResource(d)
-	if err := client.VIPServices().CreateOrUpdate(ctx, svc); err != nil {
-		return diagnosticsError(err, "Failed to update Service %q", d.Id())
+func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan serviceResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return resourceServiceRead(ctx, d, m)
+	svc := r.buildServiceFromResource(ctx, &plan, &resp.Diagnostics)
+	if err := r.Client.VIPServices().CreateOrUpdate(ctx, svc); err != nil {
+		resp.Diagnostics.AddError("Failed to update Service", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*tailscale.Client)
+func (r *serviceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state serviceResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	if err := client.VIPServices().Delete(ctx, d.Id()); err != nil && !tailscale.IsNotFound(err) {
-		return diagnosticsError(err, "Failed to delete Service %q", d.Id())
+	err := r.Client.VIPServices().Delete(ctx, state.ID.ValueString())
+	if err != nil && !tailscale.IsNotFound(err) {
+		resp.Diagnostics.AddError("Failed to delete Service", err.Error())
 	}
-
-	return nil
 }
 
-func buildServiceFromResource(d *schema.ResourceData) tailscale.VIPService {
-	svc := tailscale.VIPService{
-		Name:    d.Get("name").(string),
-		Comment: d.Get("comment").(string),
+func (d serviceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *serviceResource) buildServiceFromResource(ctx context.Context, model *serviceResourceModel, diags *diag.Diagnostics) tailscale.VIPService {
+	var ports, tags, addrs []string
+	diags.Append(model.Ports.ElementsAs(ctx, &ports, false)...)
+	diags.Append(model.Tags.ElementsAs(ctx, &tags, false)...)
+
+	if !model.Addrs.IsNull() && !model.Addrs.IsUnknown() {
+		diags.Append(model.Addrs.ElementsAs(ctx, &addrs, false)...)
 	}
 
-	if v, ok := d.GetOk("addrs"); ok {
-		addrs := v.([]interface{})
-		svc.Addrs = make([]string, len(addrs))
-		for i, a := range addrs {
-			svc.Addrs[i] = a.(string)
-		}
+	return tailscale.VIPService{
+		Name:    model.Name.ValueString(),
+		Comment: model.Comment.ValueString(),
+		Addrs:   addrs,
+		Ports:   ports,
+		Tags:    tags,
 	}
-
-	if v, ok := d.GetOk("ports"); ok {
-		ports := v.(*schema.Set).List()
-		svc.Ports = make([]string, len(ports))
-		for i, p := range ports {
-			svc.Ports[i] = p.(string)
-		}
-	}
-
-	if v, ok := d.GetOk("tags"); ok {
-		tags := v.(*schema.Set).List()
-		svc.Tags = make([]string, len(tags))
-		for i, t := range tags {
-			svc.Tags[i] = t.(string)
-		}
-	}
-
-	return svc
 }

--- a/tailscale/resource_webhook.go
+++ b/tailscale/resource_webhook.go
@@ -192,10 +192,7 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	state.EndpointURL = types.StringValue(webhook.EndpointURL)
 	state.ProviderType = StringValueNullIfEmpty(string(webhook.ProviderType))
-
-	subscriptions, diags := types.SetValueFrom(ctx, types.StringType, webhook.Subscriptions)
-	resp.Diagnostics.Append(diags...)
-	state.Subscriptions = subscriptions
+	state.Subscriptions = SetOfStringValue(ctx, webhook.Subscriptions, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
Note: this does not include migration tests, because `resource_service` didn't exist in prior versions of the provider.

Fixes tailscale/corp#40810