### PR TITLE
data_source_4via6: add a missing test for invalid `cidr` value

### DIFF
--- a/tailscale/data_source_4via6_test.go
+++ b/tailscale/data_source_4via6_test.go
@@ -47,6 +47,16 @@ func TestProvider_DataSourceTailscale4Via6_InvalidConfig(t *testing.T) {
 			`,
 			ExpectError: regexp.MustCompile(`Attribute site value must be between 0 and 65535, got: 70000`),
 		},
+		{
+			Name: "invalid-cidr",
+			Config: `
+				data "tailscale_4via6" "invalid" {
+					site = 5757
+					cidr = "not-a-cidr"
+				}
+			`,
+			ExpectError: regexp.MustCompile("Attribute cidr value must be a CIDR address, got: not-a-cidr"),
+		},
 	}
 
 	runExpectedErrorTests(t, testCases)

--- a/tailscale/validators.go
+++ b/tailscale/validators.go
@@ -21,7 +21,7 @@ var (
 type cidrValidator struct{}
 
 func (v cidrValidator) Description(_ context.Context) string {
-	return "value must be a CIDR address."
+	return "value must be a CIDR address"
 }
 
 func (v cidrValidator) MarkdownDescription(ctx context.Context) string {


### PR DESCRIPTION
Updates #cleanup