### PR TITLE
resource_{acl,oauth_client}: use `ResourceImportedByID`

### DIFF
--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -7,13 +7,17 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &aclResource{}
+	_ resource.ResourceWithImportState = &aclResource{}
 )
 
 type aclResourceModel struct {
@@ -30,6 +34,7 @@ func NewACLResource() resource.Resource {
 
 type aclResource struct {
 	ResourceBase
+	ResourceImportedByID
 }
 
 // Metadata defines the resource name as it appears in Terraform configurations.
@@ -152,8 +157,4 @@ func (r *aclResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	if err := r.Client.PolicyFile().Set(ctx, "", ""); err != nil {
 		resp.Diagnostics.AddError("Failed to reset ACL", err.Error())
 	}
-}
-
-func (r *aclResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/tailscale/resource_oauth_client.go
+++ b/tailscale/resource_oauth_client.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -40,6 +39,7 @@ func NewOAuthClientResource() resource.Resource {
 
 type oauthClientResource struct {
 	ResourceBase
+	ResourceImportedByID
 }
 
 func (r *oauthClientResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -198,8 +198,4 @@ func (r *oauthClientResource) Delete(ctx context.Context, req resource.DeleteReq
 	if err != nil && !tailscale.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete oauth client", err.Error())
 	}
-}
-
-func (r *oauthClientResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
These resources were in-flight when I wrote `ResourceImportedByID`, so they were missed when I applied it.

Updates #cleanup