### PR TITLE
tailscale: remove PreserveEmptyStringAsNull plan modifier

### DIFF
--- a/tailscale/plan_modifiers.go
+++ b/tailscale/plan_modifiers.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/tailscale/hujson"
 )
@@ -17,7 +16,6 @@ import (
 var (
 	_ planmodifier.String = jsonSemanticDiffModifier{}
 	_ planmodifier.String = aclHuJSONModifier{}
-	_ planmodifier.String = PreserveEmptyStringAsNull{}
 )
 
 // jsonSemanticDiffModifier treats strings as equivalent if they correspond
@@ -81,31 +79,5 @@ func (m aclHuJSONModifier) PlanModifyString(ctx context.Context, req planmodifie
 			resp.PlanValue = req.StateValue
 			return
 		}
-	}
-}
-
-// PreserveEmptyStringAsNull is a plan modifier that will treat empty strings in
-// the state as equivalent to null values, and not change them. This is needed
-// because the plugin SDK provider may have saved empty strings in the state for
-// certain attributes when set to null, but the plugin framework-based provider
-// will always save null strings as null. In cases where the empty string and
-// null are equivalent as far as the client or API are concerned, we therefore
-// need to change the plan to avoid changing an empty string to a null, and a
-// confusing no-op diff from Terraform. For more details, see:
-//   - https://github.com/hashicorp/terraform-plugin-framework/issues/510
-//   - https://discuss.hashicorp.com/t/framework-migration-test-produces-non-empty-plan/54523/12
-type PreserveEmptyStringAsNull struct{}
-
-func (pm PreserveEmptyStringAsNull) Description(_ context.Context) string {
-	return `If the existing value of this attribute in state is "" and the new value is null, the value of this attribute in state will remain as the empty string.`
-}
-
-func (pm PreserveEmptyStringAsNull) MarkdownDescription(_ context.Context) string {
-	return `If the existing value of this attribute in state is "" and the new value is null, the value of this attribute in state will remain as the empty string.`
-}
-
-func (pm PreserveEmptyStringAsNull) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if req.StateValue.ValueString() == "" && !req.StateValue.IsUnknown() && req.ConfigValue.IsNull() {
-		resp.PlanValue = types.StringValue("")
 	}
 }

--- a/tailscale/plan_modifiers_test.go
+++ b/tailscale/plan_modifiers_test.go
@@ -127,55 +127,6 @@ func TestAclHuJSONModifier(t *testing.T) {
 	runStringPlanModifierTests(t, aclHuJSONModifier{}, testCases)
 }
 
-func TestPreserveEmptyStringAsNull(t *testing.T) {
-	testCases := []stringPlanModifierTestCase{
-		{
-			name:         "equal-strings",
-			state:        types.StringValue("cabbage"),
-			config:       types.StringValue("cabbage"),
-			expectedPlan: types.StringValue("cabbage"),
-		},
-		{
-			name:         "different-strings",
-			state:        types.StringValue("carrot"),
-			config:       types.StringValue("lettuce"),
-			expectedPlan: types.StringValue("lettuce"),
-		},
-		{
-			name:         "empty-string-in-state-non-empty-in-plan",
-			state:        types.StringValue(""),
-			config:       types.StringValue("broccoli"),
-			expectedPlan: types.StringValue("broccoli"),
-		},
-		{
-			name:         "non-empty-string-in-state-empty-in-plan",
-			state:        types.StringValue("rhubarb"),
-			config:       types.StringValue(""),
-			expectedPlan: types.StringValue(""),
-		},
-		{
-			name:         "empty-string-in-state-unknown-plan",
-			state:        types.StringValue(""),
-			config:       types.StringUnknown(),
-			expectedPlan: types.StringUnknown(),
-		},
-		{
-			name:         "empty-string-in-state-null-plan",
-			state:        types.StringValue(""),
-			config:       types.StringNull(),
-			expectedPlan: types.StringValue(""),
-		},
-		{
-			name:         "null-in-state-empty-string-in-plan",
-			state:        types.StringNull(),
-			config:       types.StringValue(""),
-			expectedPlan: types.StringValue(""),
-		},
-	}
-
-	runStringPlanModifierTests(t, PreserveEmptyStringAsNull{}, testCases)
-}
-
 type stringPlanModifierTestCase struct {
 	name         string
 	state        types.String

--- a/tailscale/resource_federated_identity.go
+++ b/tailscale/resource_federated_identity.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -51,13 +52,13 @@ func (r *federatedIdentityResource) Schema(_ context.Context, _ resource.SchemaR
 				},
 			},
 			"description": schema.StringAttribute{
-				Description:   "A description of the federated identity consisting of alphanumeric characters. Defaults to `\"\"`.",
-				Optional:      true,
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
+				Description: "A description of the federated identity consisting of alphanumeric characters. Defaults to `\"\"`.",
+				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(50),
 				},
+				Default: stringdefault.StaticString(""),
 			},
 			"scopes": schema.SetAttribute{
 				Description: "Scopes to grant to the federated identity. See https://tailscale.com/kb/1623/ for a list of available scopes.",

--- a/tailscale/resource_posture_integration.go
+++ b/tailscale/resource_posture_integration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -72,22 +73,22 @@ func (p *postureIntegrationResource) Schema(_ context.Context, _ resource.Schema
 				},
 			},
 			"cloud_id": schema.StringAttribute{
-				Description:   "Identifies which of the provider's clouds to integrate with.",
-				Optional:      true,
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
+				Description: "Identifies which of the provider's clouds to integrate with.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"client_id": schema.StringAttribute{
-				Description:   "Unique identifier for your client.",
-				Optional:      true,
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
+				Description: "Unique identifier for your client.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"tenant_id": schema.StringAttribute{
-				Description:   "The Microsoft Intune directory (tenant) ID. For other providers, this is left blank.",
-				Optional:      true,
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{PreserveEmptyStringAsNull{}},
+				Description: "The Microsoft Intune directory (tenant) ID. For other providers, this is left blank.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"client_secret": schema.StringAttribute{
 				Description: "The secret (auth key, token, etc.) used to authenticate with the provider.",


### PR DESCRIPTION
Remove PreserveEmptyStringAsNull plan modifier and instead use default values for the empty value of the given type. This is essentially equivalent for resources that are migrating off of the plugin SDKv2 and is the more common pattern that we have consolidated on throughout the rest of the migration effort.

Updates https://github.com/tailscale/corp/issues/37032