### PR TITLE
tailscale: add missing compile-time interface assertions

### DIFF
--- a/tailscale/data_source_4via6.go
+++ b/tailscale/data_source_4via6.go
@@ -22,7 +22,11 @@ type dataSource4Via6Model struct {
 	IPv6 types.String `tfsdk:"ipv6"`
 }
 
-// New4Via6DataSource() returns a new 4via6 data source.
+var (
+	_ datasource.DataSourceWithConfigure = &dataSource4via6{}
+)
+
+// New4Via6DataSource returns a new 4via6 data source.
 func New4Via6DataSource() datasource.DataSource {
 	return &dataSource4via6{}
 }

--- a/tailscale/data_source_acl.go
+++ b/tailscale/data_source_acl.go
@@ -15,6 +15,10 @@ import (
 	"github.com/tailscale/hujson"
 )
 
+var (
+	_ datasource.DataSourceWithConfigure = &aclDataSource{}
+)
+
 // NewACLDataSource returns a new ACL data source.
 func NewACLDataSource() datasource.DataSource {
 	return &aclDataSource{}

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -19,6 +19,10 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
+var (
+	_ datasource.DataSourceWithConfigure = &singleDeviceDataSource{}
+)
+
 // NewSingleDeviceDataSource returns a new single-device data source.
 func NewSingleDeviceDataSource() datasource.DataSource {
 	return &singleDeviceDataSource{}

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -16,6 +16,10 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
+var (
+	_ datasource.DataSourceWithConfigure = &multipleDevicesDataSource{}
+)
+
 // NewMultipleDevicesDataSource returns a new multiple-users data data source.
 func NewMultipleDevicesDataSource() datasource.DataSource {
 	return &multipleDevicesDataSource{}

--- a/tailscale/data_source_service.go
+++ b/tailscale/data_source_service.go
@@ -11,7 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// NewServiceDataSource() returns a new Services data source.
+var (
+	_ datasource.DataSourceWithConfigure = &dataSourceService{}
+)
+
+// NewServiceDataSource returns a new Services data source.
 func NewServiceDataSource() datasource.DataSource {
 	return &dataSourceService{}
 }

--- a/tailscale/data_source_user.go
+++ b/tailscale/data_source_user.go
@@ -16,7 +16,11 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
-// NewUserDataSource returns a new single-user data source.
+var (
+	_ datasource.DataSourceWithConfigure = &singleUserDataSource{}
+)
+
+// NewSingleUserDataSource returns a new single-user data source.
 func NewSingleUserDataSource() datasource.DataSource {
 	return &singleUserDataSource{}
 }

--- a/tailscale/data_source_users.go
+++ b/tailscale/data_source_users.go
@@ -15,6 +15,10 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
+var (
+	_ datasource.DataSourceWithConfigure = &multipleUsersDataSource{}
+)
+
 // NewMultipleUsersDataSource returns a new multiple-users data data source.
 func NewMultipleUsersDataSource() datasource.DataSource {
 	return &multipleUsersDataSource{}

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	_ resource.Resource                = &aclResource{}
+	_ resource.ResourceWithConfigure   = &aclResource{}
 	_ resource.ResourceWithImportState = &aclResource{}
 )
 

--- a/tailscale/resource_aws_external_id.go
+++ b/tailscale/resource_aws_external_id.go
@@ -11,6 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var (
+	_ resource.Resource              = &awsExternalIDResource{}
+	_ resource.ResourceWithConfigure = &awsExternalIDResource{}
+)
+
 // NewAWSExternalIDResource returns a new AWS External ID resource.
 func NewAWSExternalIDResource() resource.Resource {
 	return &awsExternalIDResource{}

--- a/tailscale/resource_contacts.go
+++ b/tailscale/resource_contacts.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	_ resource.Resource                = &contactsResource{}
+	_ resource.ResourceWithConfigure   = &contactsResource{}
 	_ resource.ResourceWithImportState = &contactsResource{}
 )
 

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	_ resource.Resource                = &deviceAuthorizationResource{}
+	_ resource.ResourceWithConfigure   = &deviceAuthorizationResource{}
 	_ resource.ResourceWithImportState = &deviceAuthorizationResource{}
 	_ resource.ResourceWithModifyPlan  = &deviceAuthorizationResource{}
 )

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	_ resource.Resource                = &deviceKeyResource{}
+	_ resource.ResourceWithConfigure   = &deviceKeyResource{}
 	_ resource.ResourceWithImportState = &deviceKeyResource{}
 )
 

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -24,6 +24,7 @@ Note: all routes enabled for the device through the admin console or autoApprove
 
 var (
 	_ resource.Resource                = &deviceSubnetRoutesResource{}
+	_ resource.ResourceWithConfigure   = &deviceSubnetRoutesResource{}
 	_ resource.ResourceWithImportState = &deviceSubnetRoutesResource{}
 )
 

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	_ resource.Resource                = &deviceTagsResource{}
+	_ resource.ResourceWithConfigure   = &deviceTagsResource{}
 	_ resource.ResourceWithImportState = &deviceTagsResource{}
 )
 

--- a/tailscale/resource_dns_configuration.go
+++ b/tailscale/resource_dns_configuration.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	_ resource.Resource                = &dnsConfigurationResource{}
+	_ resource.ResourceWithConfigure   = &dnsConfigurationResource{}
 	_ resource.ResourceWithImportState = &dnsConfigurationResource{}
 )
 

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	_ resource.Resource                = &dnsNameserversResource{}
+	_ resource.ResourceWithConfigure   = &dnsNameserversResource{}
 	_ resource.ResourceWithImportState = &dnsNameserversResource{}
 )
 

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -16,7 +16,11 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
-var _ resource.ResourceWithImportState = &dnsPreferencesResource{}
+var (
+	_ resource.Resource                = &dnsPreferencesResource{}
+	_ resource.ResourceWithConfigure   = &dnsPreferencesResource{}
+	_ resource.ResourceWithImportState = &dnsPreferencesResource{}
+)
 
 // NewDNSPreferencesResource returns a new DNS preferences resources.
 func NewDNSPreferencesResource() resource.Resource {

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	_ resource.Resource                = &dnsSearchPathsResource{}
+	_ resource.ResourceWithConfigure   = &dnsSearchPathsResource{}
 	_ resource.ResourceWithImportState = &dnsSearchPathsResource{}
 )
 

--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	_ resource.Resource                = &dnsSplitNameserversResource{}
+	_ resource.ResourceWithConfigure   = &dnsSplitNameserversResource{}
 	_ resource.ResourceWithImportState = &dnsSplitNameserversResource{}
 )
 

--- a/tailscale/resource_federated_identity.go
+++ b/tailscale/resource_federated_identity.go
@@ -24,6 +24,12 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
+var (
+	_ resource.Resource                = &federatedIdentityResource{}
+	_ resource.ResourceWithConfigure   = &federatedIdentityResource{}
+	_ resource.ResourceWithImportState = &federatedIdentityResource{}
+)
+
 // NewFederatedIdentityResource returns a new federated identity resource.
 func NewFederatedIdentityResource() resource.Resource {
 	return &federatedIdentityResource{}

--- a/tailscale/resource_logstream_configuration.go
+++ b/tailscale/resource_logstream_configuration.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	_ resource.Resource                = &logstreamConfigurationResource{}
+	_ resource.ResourceWithConfigure   = &logstreamConfigurationResource{}
 	_ resource.ResourceWithImportState = &logstreamConfigurationResource{}
 )
 

--- a/tailscale/resource_oauth_client.go
+++ b/tailscale/resource_oauth_client.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	_ resource.Resource                = &oauthClientResource{}
+	_ resource.ResourceWithConfigure   = &oauthClientResource{}
 	_ resource.ResourceWithImportState = &oauthClientResource{}
 )
 

--- a/tailscale/resource_service.go
+++ b/tailscale/resource_service.go
@@ -22,7 +22,8 @@ import (
 
 var (
 	_ resource.Resource                = &serviceResource{}
-	_ resource.ResourceWithImportState = &webhookResource{}
+	_ resource.ResourceWithConfigure   = &serviceResource{}
+	_ resource.ResourceWithImportState = &serviceResource{}
 )
 
 type serviceResourceModel struct {

--- a/tailscale/resource_webhook.go
+++ b/tailscale/resource_webhook.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	_ resource.Resource                = &webhookResource{}
+	_ resource.ResourceWithConfigure   = &webhookResource{}
 	_ resource.ResourceWithImportState = &webhookResource{}
 )
 


### PR DESCRIPTION
Add missing compile-time interface assertions for migrated resources.

Updates https://github.com/tailscale/corp/issues/37032