### PR TITLE
provider_sdk: migrate validateProviderCreds to use Go error types

### DIFF
--- a/tailscale/provider_framework.go
+++ b/tailscale/provider_framework.go
@@ -158,7 +158,7 @@ func (p *tailscaleProvider) Configure(ctx context.Context, req provider.Configur
 	}
 
 	if err := validateProviderCreds(apiKey, oauthClientID, oauthClientSecret, identityToken, audience); err != nil {
-		resp.Diagnostics.AddError("Provider credentials error", err[0].Summary)
+		resp.Diagnostics.AddError("Provider credentials error", err.Error())
 	}
 
 	if resp.Diagnostics.HasError() {

--- a/tailscale/provider_sdk.go
+++ b/tailscale/provider_sdk.go
@@ -139,8 +139,8 @@ func providerConfigure(_ context.Context, provider *schema.Provider, d *schema.R
 	}
 	audience := d.Get("audience").(string)
 
-	if diags := validateProviderCreds(apiKey, oauthClientID, oauthClientSecret, idToken, audience); diags != nil && diags.HasError() {
-		return nil, diags
+	if err := validateProviderCreds(apiKey, oauthClientID, oauthClientSecret, idToken, audience); err != nil {
+		return nil, diag.Errorf("%s", err.Error())
 	}
 
 	userAgent := d.Get("user_agent").(string)
@@ -163,17 +163,17 @@ func providerConfigure(_ context.Context, provider *schema.Provider, d *schema.R
 	return &client, nil
 }
 
-func validateProviderCreds(apiKey, oauthClientID, oauthClientSecret, idToken, audience string) diag.Diagnostics {
+func validateProviderCreds(apiKey, oauthClientID, oauthClientSecret, idToken, audience string) error {
 	if apiKey == "" && oauthClientID == "" && oauthClientSecret == "" && idToken == "" && audience == "" {
-		return diag.Errorf("tailscale provider credentials are empty - set `api_key` or 'oauth_client_id' and one of 'oauth_client_secret', 'identity_token', or 'audience'")
+		return errors.New("tailscale provider credentials are empty - set `api_key` or 'oauth_client_id' and one of 'oauth_client_secret', 'identity_token', or 'audience'")
 	} else if apiKey != "" && (oauthClientID != "" || oauthClientSecret != "" || idToken != "" || audience != "") {
-		return diag.Errorf("tailscale provider credentials are conflicting - `api_key` conflicts with 'oauth_client_id', 'oauth_client_secret', 'identity_token', and 'audience'")
+		return errors.New("tailscale provider credentials are conflicting - `api_key` conflicts with 'oauth_client_id', 'oauth_client_secret', 'identity_token', and 'audience'")
 	} else if audience != "" && (oauthClientSecret != "" || idToken != "") {
-		return diag.Errorf("tailscale provider argument 'audience' conflicts with 'oauth_client_secret' and 'identity_token'")
+		return errors.New("tailscale provider argument 'audience' conflicts with 'oauth_client_secret' and 'identity_token'")
 	} else if apiKey == "" && oauthClientID == "" {
-		return diag.Errorf("tailscale provider argument 'oauth_client_id' is empty")
+		return errors.New("tailscale provider argument 'oauth_client_id' is empty")
 	} else if oauthClientID != "" && oauthClientSecret == "" && idToken == "" && audience == "" {
-		return diag.Errorf("one of tailscale provider arguments 'oauth_client_secret', 'identity_token', or 'audience' are mandatory with 'oauth_client_id'")
+		return errors.New("one of tailscale provider arguments 'oauth_client_secret', 'identity_token', or 'audience' are mandatory with 'oauth_client_id'")
 	}
 
 	return nil

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -345,31 +345,21 @@ func TestValidateProviderCreds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			diags := validateProviderCreds(tt.apiKey, tt.oauthClientID, tt.oauthSecret, tt.idToken, tt.audience)
+			err := validateProviderCreds(tt.apiKey, tt.oauthClientID, tt.oauthSecret, tt.idToken, tt.audience)
 
-			if tt.wantErr == "" && diags.HasError() {
-				t.Errorf("unexpected error: %v", diags)
+			if tt.wantErr == "" && err != nil {
+				t.Errorf("unexpected error: %v", err)
 
 			}
 
-			if tt.wantErr != "" && !diags.HasError() {
+			if tt.wantErr != "" && err == nil {
 				t.Errorf("expected error containing %q but got none", tt.wantErr)
 				return
 			}
 
 			if tt.wantErr != "" {
-				match := false
-				for _, d := range diags {
-					if d.Severity == diag.Error {
-						errMsg := d.Summary + d.Detail
-						if strings.Contains(errMsg, tt.wantErr) {
-							match = true
-							break
-						}
-					}
-				}
-				if !match {
-					t.Errorf("expected error containing %q but got: %v", tt.wantErr, diags)
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q but got: %v", tt.wantErr, err)
 				}
 			}
 		})


### PR DESCRIPTION
This decouples it from the plugin SDK.

Updates tailscale/corp#37221