### PR TITLE
resource_oauth_client: fix drift when tags are empty

### DIFF
--- a/tailscale/resource_oauth_client.go
+++ b/tailscale/resource_oauth_client.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -65,8 +67,10 @@ func (r *oauthClientResource) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"tags": schema.SetAttribute{
 				ElementType: types.StringType,
+				Computed:    true,
 				Optional:    true,
 				Description: "A list of tags that access tokens generated for the OAuth client will be able to assign to devices. Mandatory if the scopes include \"devices:core\" or \"auth_keys\".",
+				Default:     setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 			},
 			"id": schema.StringAttribute{
 				Description: "The client ID, also known as the key id. Used with the client secret to generate access tokens.",
@@ -127,6 +131,10 @@ func (r *oauthClientResource) Read(ctx context.Context, req resource.ReadRequest
 	state.UpdatedAt = types.StringValue(key.Updated.Format(time.RFC3339))
 	state.UserID = types.StringValue(key.UserID)
 	state.Scopes = SetOfStringValue(ctx, key.Scopes, &resp.Diagnostics)
+
+	if key.Tags == nil {
+		key.Tags = []string{}
+	}
 	state.Tags = SetOfStringValue(ctx, key.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/tailscale/resource_oauth_client_test.go
+++ b/tailscale/resource_oauth_client_test.go
@@ -58,6 +58,19 @@ func TestAccTailscaleOAuthClient(t *testing.T) {
 			scopes      = ["auth_keys:read"]
 		}`
 
+	const testOauthClientOptionalUnset = `
+		resource "tailscale_oauth_client" "test_client" {
+			description = "Updated description" # TODO(zofrex): fix this as well
+			scopes      = ["auth_keys:read"]
+		}`
+
+	const testOauthClientOptionalEmpty = `
+		resource "tailscale_oauth_client" "test_client" {
+			description = "Updated description" # TODO(zofrex): fix this as well
+			scopes      = ["auth_keys:read"]
+			tags        = []
+		}`
+
 	var expectedOAuthClientCreated tailscale.Key
 	expectedOAuthClientCreated.Description = "Test client"
 	expectedOAuthClientCreated.KeyType = "client"
@@ -161,6 +174,12 @@ func TestAccTailscaleOAuthClient(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
 				),
+			},
+			{
+				Config: testOauthClientOptionalUnset,
+			},
+			{
+				Config: testOauthClientOptionalEmpty,
 			},
 			{
 				ResourceName:            resourceName,


### PR DESCRIPTION
Without this patch, the following will always show a diff:

```
resource "tailscale_oauth_client" "test_client" {
  description = "Updated description"
  scopes      = ["auth_keys:read"]
  tags = []
}
```

e.g.:
```
# tailscale_oauth_client.test_client will be updated in-place
  ~ resource "tailscale_oauth_client" "test_client" {
        id          = "kPmdpCNpRA11DEVEL"
      + tags        = []
      ~ updated_at  = "2026-05-06T06:41:24Z" -> (known after apply)
        # (5 unchanged attributes hidden)
    }
```

This patch sets a default value of `[]`, the same as how `resource_tailnet_key` works.

Updates tailscale/corp#37032