### PR TITLE
resource_oauth_client: fix drift when description is null

### DIFF
--- a/tailscale/resource_oauth_client.go
+++ b/tailscale/resource_oauth_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,10 +56,12 @@ func (r *oauthClientResource) Schema(_ context.Context, _ resource.SchemaRequest
 		Attributes: map[string]schema.Attribute{
 			"description": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "A description of the OAuth client consisting of alphanumeric characters. Defaults to `\"\"`.",
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(50),
 				},
+				Default: stringdefault.StaticString(""),
 			},
 			"scopes": schema.SetAttribute{
 				ElementType: types.StringType,

--- a/tailscale/resource_oauth_client_test.go
+++ b/tailscale/resource_oauth_client_test.go
@@ -60,13 +60,12 @@ func TestAccTailscaleOAuthClient(t *testing.T) {
 
 	const testOauthClientOptionalUnset = `
 		resource "tailscale_oauth_client" "test_client" {
-			description = "Updated description" # TODO(zofrex): fix this as well
 			scopes      = ["auth_keys:read"]
 		}`
 
 	const testOauthClientOptionalEmpty = `
 		resource "tailscale_oauth_client" "test_client" {
-			description = "Updated description" # TODO(zofrex): fix this as well
+			description = ""
 			scopes      = ["auth_keys:read"]
 			tags        = []
 		}`


### PR DESCRIPTION
Without this patch, a diff will always be shown when the description is null:

```terraform
resource "tailscale_oauth_client" "test_client" {
  scopes      = ["auth_keys:read"]
}
```

This patch sets a default value of `""` (which is what the API sends back for an unset description) which resolves the apparent drift.

Stacked on #743

Updates tailscale/corp#37032