### PR TITLE
resource_service: fix drift when tags are empty

### DIFF
--- a/tailscale/resource_service.go
+++ b/tailscale/resource_service.go
@@ -8,11 +8,13 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -95,8 +97,10 @@ func (r *serviceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"tags": schema.SetAttribute{
 				Description: "The ACL tags applied to the Service.",
+				Computed:    true,
 				Optional:    true,
 				ElementType: types.StringType,
+				Default:     setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 			},
 		},
 	}
@@ -154,6 +158,9 @@ func (r *serviceResource) Read(ctx context.Context, req resource.ReadRequest, re
 	state.Comment = types.StringValue(svc.Comment)
 	state.Addrs = ListOfStringValue(ctx, svc.Addrs, &resp.Diagnostics)
 	state.Ports = SetOfStringValue(ctx, svc.Ports, &resp.Diagnostics)
+	if svc.Tags == nil {
+		svc.Tags = []string{}
+	}
 	state.Tags = SetOfStringValue(ctx, svc.Tags, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/tailscale/resource_service_test.go
+++ b/tailscale/resource_service_test.go
@@ -53,6 +53,21 @@ func TestProvider_TailscaleService(t *testing.T) {
 func TestAccTailscaleService(t *testing.T) {
 	const resourceName = "tailscale_service.test_service"
 
+	const testServiceOptionalUnset = `
+		resource "tailscale_service" "test_service" {
+			name    = "svc:test-service"
+			comment = "a test Service" # TODO(zofrex): fix this one too
+			ports   = ["tcp:443", "tcp:8080"]
+		}`
+
+	const testServiceOptionalEmpty = `
+		resource "tailscale_service" "test_service" {
+			name    = "svc:test-service"
+			comment = "a test Service" # TODO(zofrex): fix this one too
+			ports   = ["tcp:443", "tcp:8080"]
+			tags    = []
+		}`
+
 	checkProperties := func(expectedComment string, expectedPorts []string, expectedTags []string) func(client *tailscale.Client, rs *terraform.ResourceState) error {
 		return func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			svc, err := client.VIPServices().Get(context.Background(), rs.Primary.ID)
@@ -129,6 +144,12 @@ func TestAccTailscaleService(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "ports.*", "tcp:443"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "ports.*", "tcp:8080"),
 				),
+			},
+			{
+				Config: testServiceOptionalUnset,
+			},
+			{
+				Config: testServiceOptionalEmpty,
 			},
 			{
 				ResourceName:      resourceName,


### PR DESCRIPTION
Without this patch, the following will always show a diff:

```terraform
resource "tailscale_service" "test_service" {
  name    = "svc:test-service"
  comment = ""
  ports   = ["tcp:443", "tcp:8080"]
  tags    = []
}
```

e.g.:

```
  # tailscale_service.test_service will be updated in-place
  ~ resource "tailscale_service" "test_service" {
        id    = "svc:test-service"
        name  = "svc:test-service"
      + tags  = []
        # (2 unchanged attributes hidden)
    }
```

This patch sets a default value of [], the same as how resource_tailnet_key works.

Updates tailscale/corp#37032
