### PR TITLE
resource_service: fix drift when comment is null

### DIFF
--- a/tailscale/resource_service.go
+++ b/tailscale/resource_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -88,7 +89,9 @@ func (r *serviceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"comment": schema.StringAttribute{
 				Description: "An optional comment describing the Service.",
+				Computed:    true,
 				Optional:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"ports": schema.SetAttribute{
 				Description: "A list of protocol:port pairs to be exposed by the Service. The only supported protocol is \"tcp\" at this time. \"do-not-validate\" can be used to skip validation.",

--- a/tailscale/resource_service_test.go
+++ b/tailscale/resource_service_test.go
@@ -56,14 +56,13 @@ func TestAccTailscaleService(t *testing.T) {
 	const testServiceOptionalUnset = `
 		resource "tailscale_service" "test_service" {
 			name    = "svc:test-service"
-			comment = "a test Service" # TODO(zofrex): fix this one too
 			ports   = ["tcp:443", "tcp:8080"]
 		}`
 
 	const testServiceOptionalEmpty = `
 		resource "tailscale_service" "test_service" {
 			name    = "svc:test-service"
-			comment = "a test Service" # TODO(zofrex): fix this one too
+			comment = ""
 			ports   = ["tcp:443", "tcp:8080"]
 			tags    = []
 		}`


### PR DESCRIPTION
Without this patch, we will always get a diff when `comment` is null, e.g.:

```terraform
resource "tailscale_service" "test_service_foo" {
  name    = "svc:test-service"
  ports   = ["tcp:443", "tcp:8080"]
}
```

Produces this diff on apply every time:

```
  # tailscale_service.test_service_foo will be updated in-place
  ~ resource "tailscale_service" "test_service_foo" {
        id    = "svc:test-service"
        name  = "svc:test-service"
        tags  = []
        # (2 unchanged attributes hidden)
    }
```

This patch sets a default value of `""` (which is what the API sends back for an unset comment) which resolves the apparent drift.

Updates tailscale/corp#37032