### PR TITLE
resource_device_tags: fix drift when tags are empty

### DIFF
--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -95,6 +95,9 @@ func (d deviceTagsResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	state.DeviceID = types.StringValue(canonicalDeviceID)
+	if device.Tags == nil {
+		device.Tags = []string{}
+	}
 	state.Tags = SetOfStringValue(ctx, device.Tags, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -6,6 +6,7 @@ package tailscale
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
@@ -16,6 +17,31 @@ import (
 	"tailscale.com/client/tailscale/v2"
 )
 
+func TestProvider_TailscaleDeviceTags(t *testing.T) {
+	const testDeviceTagsCreateEmpty = `
+		resource "tailscale_device_tags" "test_tags" {
+			device_id = "device1CNTRL"
+			tags = []
+		}`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = tailscale.Device{
+				ID:   "device1CNTRL",
+				Tags: nil,
+			}
+		},
+		ProtoV5ProviderFactories: testProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceTagsCreateEmpty,
+			},
+		},
+	})
+}
+
 func TestAccTailscaleDeviceTags(t *testing.T) {
 	const resourceName = "tailscale_device_tags.test_tags"
 
@@ -24,7 +50,7 @@ func TestAccTailscaleDeviceTags(t *testing.T) {
 			name = "%s"
 			wait_for = "60s"
 		}
-		
+
 		resource "tailscale_device_tags" "test_tags" {
 			device_id = data.tailscale_device.test_device.id
 			tags = [


### PR DESCRIPTION
Without this patch, we will always get a diff when `tags` is an empty list, e.g.:

```terraform
resource "tailscale_device_tags" "test_tags" {
  device_id = data.tailscale_device.test_device.id
  tags = []
}
```

Produces this diff on apply every time:

```
  # tailscale_device_tags.test_tags will be updated in-place
  ~ resource "tailscale_device_tags" "test_tags" {
      ~ id        = "1333080874923104" -> (known after apply)
      + tags      = []
        # (1 unchanged attribute hidden)
    }
```

This patch sets a default value of `[]`, the same as how `resource_tailnet_key` works.

Updates tailscale/corp#37032