### PR TITLE
resource_federated_identity: don't permit empty audience

### DIFF
--- a/tailscale/resource_federated_identity.go
+++ b/tailscale/resource_federated_identity.go
@@ -85,6 +85,9 @@ func (r *federatedIdentityResource) Schema(_ context.Context, _ resource.SchemaR
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"subject": schema.StringAttribute{
 				Description: "The pattern used when matching against the `sub` claim from an OIDC identity token. Patterns can include `*` characters to match against any character.",


### PR DESCRIPTION
If audience is not specified (null) then one will be generated by the server, and the audience attribute on the federated_identity resource will be populated with the generated value.

As far as the server is concerned, an empty string is equivalent to not specifying it, and will prompt one to be generated. However, when using the Terraform plugin framework, Terraform is not happy if a non-null value is set by the provider on read:

> Error: Provider produced inconsistent result after apply
>
> When applying changes to tailscale_federated_identity.example, provider
> "provider[\"registry.terraform.io/tailscale/tailscale\"]" produced an
> unexpected new value: .audience: was cty.StringVal(""), but now
> cty.StringVal("api.tailscale.com/TspTWSHJkZ11DEVEL-k2Ri56KzFj11DEVEL").
>
> This is a bug in the provider, which should be reported in the provider's
> own issue tracker.

Our options are to either throw the above error when audience is set to "", or prevent them from doing so in the first place.

Not permitting a previously permitted value could be considered a breaking change. However, we have no other options, and additionally it is consistent with Terraform's guidance on patch number increments to match behaviour with the remote API:

https://developer.hashicorp.com/terraform/plugin/best-practices/versioning#example-patch-number-increments

Updates tailscale/corp#37032