### PR TITLE
resource_dns_configuration: fix drift when search paths are empty

### DIFF
--- a/tailscale/resource_dns_configuration.go
+++ b/tailscale/resource_dns_configuration.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -57,6 +59,8 @@ func (r *dnsConfigurationResource) Schema(_ context.Context, _ resource.SchemaRe
 				Description: "Additional search domains. When MagicDNS is on, the tailnet domain is automatically included as the first search domain.",
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 			},
 			"override_local_dns": schema.BoolAttribute{
 				Description: "When enabled, use the configured DNS servers in `nameservers` to resolve names outside the tailnet. When disabled, devices will prefer their local DNS configuration. Defaults to false.",
@@ -185,6 +189,9 @@ func (r *dnsConfigurationResource) Read(ctx context.Context, req resource.ReadRe
 		})
 	}
 	state.SplitDNS = splitDNS
+	if remote.SearchPaths == nil {
+		remote.SearchPaths = []string{}
+	}
 	state.SearchPaths = ListOfStringValue(ctx, remote.SearchPaths, &resp.Diagnostics)
 	state.OverrideLocalDNS = types.BoolValue(remote.Preferences.OverrideLocalDNS)
 	state.MagicDNS = types.BoolValue(remote.Preferences.MagicDNS)

--- a/tailscale/resource_dns_configuration_test.go
+++ b/tailscale/resource_dns_configuration_test.go
@@ -62,6 +62,15 @@ const testDNSConfigurationUpdate = `
 		magic_dns = false
 	}`
 
+const testDNSConfigurationOptionalUnset = `
+	resource "tailscale_dns_configuration" "test_configuration" {
+	}`
+
+const testDNSConfigurationOptionalEmpty = `
+	resource "tailscale_dns_configuration" "test_configuration" {
+		search_paths       = []
+	}`
+
 func TestProvider_TailscaleDNSConfiguration(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -162,6 +171,12 @@ func TestAccTailscaleDNSConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "override_local_dns", "false"),
 					resource.TestCheckResourceAttr(resourceName, "magic_dns", "false"),
 				),
+			},
+			{
+				Config: testDNSConfigurationOptionalUnset,
+			},
+			{
+				Config: testDNSConfigurationOptionalEmpty,
 			},
 			{
 				ResourceName:      resourceName,


### PR DESCRIPTION
Fix drift when search_paths are set to an explicitly empty list.

Without this patch there is always a diff when `search_paths` is an empty list, e.g.:

```hcl
resource "tailscale_dns_configuration" "test_configuration" {
    search_paths       = []
}
```

produces a diff on apply every time:

```
# tailscale_dns_configuration.test_configuration will be updated in-place
~ resource "tailscale_dns_configuration" "test_configuration" {
      id                 = "2b70c41f-3473-e4d2-501e-66a81b3477c9"
    + search_paths       = []
      # (2 unchanged attributes hidden)
  }
```

Updates https://github.com/tailscale/corp/issues/37032