### PR TITLE
resource_dns_split_nameservers: fix drift when nameservers is empty

### DIFF
--- a/tailscale/resource_dns_split_nameservers.go
+++ b/tailscale/resource_dns_split_nameservers.go
@@ -89,6 +89,9 @@ func (r *dnsSplitNameserversResource) Read(ctx context.Context, req resource.Rea
 
 	domain := state.Domain.ValueString()
 	nameservers := splitDNS[domain]
+	if nameservers == nil {
+		nameservers = []string{}
+	}
 	state.Nameservers = SetOfStringValue(ctx, nameservers, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {

--- a/tailscale/resource_dns_split_nameservers_test.go
+++ b/tailscale/resource_dns_split_nameservers_test.go
@@ -52,6 +52,12 @@ func TestAccTailscaleDNSSplitNameservers(t *testing.T) {
 			nameservers = ["8.8.9.9"]
 		}`
 
+	const testSplitNameserversEmpty = `
+		resource "tailscale_dns_split_nameservers" "test_nameservers" {
+			domain = "sub.example.com"
+			nameservers = []
+		}`
+
 	const testSplitNameserversUpdateSameDomain = `
 		resource "tailscale_dns_split_nameservers" "test_nameservers" {
 			domain = "sub.example.com"
@@ -99,6 +105,14 @@ func TestAccTailscaleDNSSplitNameservers(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain", "sub.example.com"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.7.7"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "nameservers.*", "8.8.9.9"),
+				),
+			},
+			{
+				Config: testSplitNameserversEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkSplitDNSProperties(tailscale.SplitDNSResponse{}),
+					),
 				),
 			},
 			{


### PR DESCRIPTION
Without this patch, we will always get a diff when `nameservers` is `[]`, e.g.:

```terraform
resource "tailscale_dns_split_nameservers" "test_nameservers" {
  domain = "example.com"
  nameservers = []
}
```

Produces this diff on apply every time:

```
  # tailscale_dns_split_nameservers.test_nameservers will be updated in-place
  ~ resource "tailscale_dns_split_nameservers" "test_nameservers" {
        id          = "example.com"
      + nameservers = []
        # (1 unchanged attribute hidden)
    }
```

This patch sets a default value of `[]` to fix it. (Note that this parameter is required, `null` is not valid, so no default is needed, and that `[]` is a valid value to set.)

Updates tailscale/corp#37032