### PR TITLE
resource_dns_configuration: error if no nameservers provided for splitdns

### DIFF
--- a/tailscale/resource_dns_configuration.go
+++ b/tailscale/resource_dns_configuration.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -107,8 +106,9 @@ func (r *dnsConfigurationResource) Schema(_ context.Context, _ resource.SchemaRe
 					Blocks: map[string]schema.Block{
 						"nameservers": schema.ListNestedBlock{
 							Description: "Set the nameservers used by devices on your network to resolve DNS queries.",
+
 							Validators: []validator.List{
-								listvalidator.SizeAtLeast(1),
+								AtLeastOneBlockRequired(),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{

--- a/tailscale/resource_dns_configuration_test.go
+++ b/tailscale/resource_dns_configuration_test.go
@@ -6,6 +6,7 @@ package tailscale
 import (
 	"context"
 	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -71,6 +72,13 @@ const testDNSConfigurationOptionalEmpty = `
 		search_paths       = []
 	}`
 
+const testDNSConfigurationNoNameservers = `
+	resource "tailscale_dns_configuration" "test_configuration" {
+		split_dns {
+			domain = "bar.example.com"
+		}
+	}`
+
 func TestProvider_TailscaleDNSConfiguration(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -82,6 +90,13 @@ func TestProvider_TailscaleDNSConfiguration(t *testing.T) {
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_configuration.test_configuration", testDNSConfigurationCreate),
 			testResourceDestroyed("tailscale_dns_configuration.test_configuration", testDNSConfigurationCreate),
+			resource.TestStep{
+				PreConfig: func() {
+
+				},
+				Config:      testDNSConfigurationNoNameservers,
+				ExpectError: regexp.MustCompile(`nameservers.*blocks`),
+			},
 		},
 	})
 }

--- a/tailscale/validator_test.go
+++ b/tailscale/validator_test.go
@@ -4,9 +4,12 @@
 package tailscale
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -92,6 +95,76 @@ func TestAclHuJSONValidator(t *testing.T) {
 	}
 
 	runStringValidatorTests(t, aclHuJSONValidator{}, testCases)
+}
+
+func TestAtLeastOneBlockRequiredValidator(t *testing.T) {
+	const blockName = "blockName"
+	block := types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})
+
+	testCases := []struct {
+		name    string
+		config  types.List
+		wantErr bool
+	}{
+		{
+			name:    "one-block",
+			config:  types.ListValueMust(types.ObjectType{}, []attr.Value{block}),
+			wantErr: false,
+		},
+		{
+			name:    "multiple-blocks",
+			config:  types.ListValueMust(types.ObjectType{}, []attr.Value{block, block}),
+			wantErr: false,
+		},
+		{
+			name:    "no-blocks",
+			config:  types.ListValueMust(types.ObjectType{}, []attr.Value{}),
+			wantErr: true,
+		},
+		{
+			name:    "null",
+			config:  types.ListNull(types.ObjectType{}),
+			wantErr: true,
+		},
+		{
+			name:    "unknown",
+			config:  types.ListUnknown(types.ObjectType{}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.ListRequest{
+				ConfigValue: tt.config,
+				Path:        path.Empty().AtName("parent").AtName(blockName),
+			}
+
+			resp := validator.ListResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			atLeastOneBlockRequiredValidator{}.ValidateList(t.Context(), req, &resp)
+
+			errors := resp.Diagnostics.Errors()
+			errorCount := len(errors)
+			if tt.wantErr {
+				if errorCount != 1 {
+					t.Errorf("got %d errors, want 1 error", errorCount)
+				} else {
+					gotErr := errors[0]
+					if !strings.Contains(gotErr.Detail(), blockName) {
+						t.Errorf("got error %q, want error to contain %q", gotErr.Detail(), blockName)
+					}
+					if !strings.Contains(gotErr.Summary(), blockName) {
+						t.Errorf("got error %q, want error to contain %q", gotErr.Summary(), blockName)
+					}
+				}
+			} else if errorCount != 0 {
+				t.Errorf("got %d errors, want 0 errors: %v", errorCount, errors)
+			}
+		})
+	}
 }
 
 type stringValidatorTestCase struct {

--- a/tailscale/validators.go
+++ b/tailscale/validators.go
@@ -5,11 +5,13 @@ package tailscale
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/tailscale/hujson"
 )
@@ -18,6 +20,7 @@ var (
 	_ validator.String = cidrValidator{}
 	_ validator.String = retryDeadlineValidator{}
 	_ validator.String = aclHuJSONValidator{}
+	_ validator.List   = atLeastOneBlockRequiredValidator{}
 )
 
 // cidrValidator is a [validator.String] for CIDR addresses.
@@ -105,4 +108,43 @@ func (v aclHuJSONValidator) ValidateString(ctx context.Context, req validator.St
 			err.Error(),
 		))
 	}
+}
+
+// atLeastOneBlockRequiredValidator validates that a list has a configuration
+// value. Intended for use with `schema.ListNestedBlock`.
+type atLeastOneBlockRequiredValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v atLeastOneBlockRequiredValidator) Description(_ context.Context) string {
+	return "must have at least one nested block configured"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v atLeastOneBlockRequiredValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate performs the validation.
+func (v atLeastOneBlockRequiredValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	len := req.ConfigValue.Length(basetypes.CollectionLengthOptions{
+		UnhandledNullAsZero:    true,
+		UnhandledUnknownAsZero: true,
+	})
+	if len == 0 {
+		last, _ := req.Path.Steps().LastStep()
+		resp.Diagnostics.AddAttributeError(req.Path,
+			fmt.Sprintf("Insufficient %s blocks", last),
+			fmt.Sprintf("At least 1 %q blocks are required.", last))
+	}
+}
+
+// AtLeastOneBlockRequired returns a validator which ensures that at least one
+// instance of the nested block is configured.
+//
+// This validator is similar to the `Required` field on attributes and is only
+// practical for use with `schema.ListNestedBlock`.
+//
+// Unlike [listvalidator.SizeAtLeast] it does not ignore null or unknown values.
+func AtLeastOneBlockRequired() validator.List {
+	return atLeastOneBlockRequiredValidator{}
 }


### PR DESCRIPTION
Without this patch, the following terraform plans successfully:

```terraform
resource "tailscale_dns_configuration" "test_configuration" {
  split_dns {
    domain             = "foo.example.com"
    # nameservers {
    #   address            = "1.1.1.3"
    # }
  }
}
```

Which then errors on applying:

```
╷
│ Error: Failed to set DNS configuration
│
│   with tailscale_dns_configuration.test_configuration,
│   on main.tf line 63, in resource "tailscale_dns_configuration" "test_configuration":
│   63: resource "tailscale_dns_configuration" "test_configuration" {
│
│ invalid character 'I' looking for beginning of value
╵
```

The schema has a validator:

```
	Validators: []validator.List{
		listvalidator.SizeAtLeast(1),
	},
```

But the docs for `SizeAtLeast` explains why this has no effect:

> Null (unconfigured) and unknown (known after apply) values are skipped.

The previous version of the plugin provides a nice error message on plan here:

```
│ Error: Insufficient nameservers blocks
│
│   on main.tf line 64, in resource "tailscale_dns_configuration" "test_configuration":
│   64:   split_dns {
│
│ At least 1 "nameservers" blocks are required.
```

We could use the `listvalidator.IsRequired` validator, which even suggests it's an appropriate validator for the scenario:

```
// This validator is equivalent to the `Required` field on attributes and is only
// practical for use with `schema.ListNestedBlock`
```

But that produces a much less helpful error message:

```
│ Error: Invalid Block
│
│   with tailscale_dns_configuration.test_configuration,
│   on main.tf line 64, in resource "tailscale_dns_configuration" "test_configuration":
│   64:   split_dns {
│
│ Block split_dns[0].nameservers must have a configuration value as the provider has marked it as required
```

Instead, I've added a custom validator, `AtLeastOneBlockRequired`, that checks that the provided `ListNestedBlock` is not null and has length at least 1, and provides this error message if it does not:

```
│ Error: Insufficient nameservers blocks
│
│   with tailscale_dns_configuration.test_configuration,
│   on main.tf line 64, in resource "tailscale_dns_configuration" "test_configuration":
│   64:   split_dns {
│
│ At least 1 "nameservers" blocks are required.
╵
```

Updates tailscale/corp#37032