### PR TITLE
resource_dns_search_paths: treat nil paths as empty

### DIFF
--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -77,6 +77,9 @@ func (r *dnsSearchPathsResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if paths == nil {
+		paths = []string{}
+	}
 	state.SearchPaths = ListOfStringValue(ctx, paths, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -47,6 +47,11 @@ func TestProvider_TailscaleDNSSearchPaths(t *testing.T) {
 func TestAccTailscaleDNSSearchPaths(t *testing.T) {
 	const resourceName = "tailscale_dns_search_paths.test_search_paths"
 
+	const testSearchPathsEmpty = `
+	resource "tailscale_dns_search_paths" "test_search_paths" {
+		search_paths = []
+	}`
+
 	checkProperties := func(expected []string) func(client *tailscale.Client, rs *terraform.ResourceState) error {
 		return func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			actual, err := client.DNS().SearchPaths(context.Background())
@@ -85,6 +90,9 @@ func TestAccTailscaleDNSSearchPaths(t *testing.T) {
 					),
 					resource.TestCheckTypeSetElemAttr(resourceName, "search_paths.*", "example.com"),
 				),
+			},
+			{
+				Config: testSearchPathsEmpty,
 			},
 			{
 				ResourceName:      resourceName,


### PR DESCRIPTION
Currently the API returns an empty list of paths if there are none, the field is not omitempty/omitzero, but we should not depend on this detail and should be defensive against it.

Updates tailscale/corp#37032