### PR TITLE
resource_device_subnet_routes: treat nil routes as empty

### DIFF
--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -108,6 +108,10 @@ func (d deviceSubnetRoutesResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
+	if deviceRoutes.Enabled == nil {
+		deviceRoutes.Enabled = []string{}
+	}
+
 	state.Routes = SetOfStringValue(ctx, deviceRoutes.Enabled, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -369,6 +369,16 @@ func TestAccTailscaleDeviceSubnetRoutes_LegacyIDToNodeID(t *testing.T) {
 			]
 		}`
 
+	const testDeviceSubnetRoutesEmpty = `
+		data "tailscale_device" "test_device" {
+			name = "%s"
+		}
+
+		resource "tailscale_device_subnet_routes" "test_subnet_routes" {
+			device_id = data.tailscale_device.test_device.node_id
+			routes = []
+		}`
+
 	checkProperties := func(expectedRoutes []string) func(client *tailscale.Client, rs *terraform.ResourceState) error {
 		return func(client *tailscale.Client, rs *terraform.ResourceState) error {
 			deviceID := rs.Primary.Attributes["device_id"]
@@ -425,6 +435,12 @@ func TestAccTailscaleDeviceSubnetRoutes_LegacyIDToNodeID(t *testing.T) {
 					checkResourceRemoteProperties(resourceName, checkLegacyID),
 					resource.TestCheckTypeSetElemAttr(resourceName, "routes.*", "10.0.1.0/24"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "routes.*", "2.0.0.0/24"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testDeviceSubnetRoutesEmpty, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkProperties([]string{})),
 				),
 			},
 			{


### PR DESCRIPTION
Currently the API returns an empty list of enabled routes if there are none, the field is not omitempty/omitzero, but we should not depend on this detail and should be defensive against it.

Updates tailscale/corp#37032
