### PR TITLE
resource_device_key: fix drift when key_expiry_disabled is null

### DIFF
--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -56,7 +57,9 @@ func (d deviceKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"key_expiry_disabled": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Determines whether or not the device's key will expire. Defaults to `false`.",
+				Default:     booldefault.StaticBool(false),
 			},
 		},
 	}

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -23,7 +23,7 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 		data "tailscale_device" "test_device" {
 			name = "%s"
 		}
-		
+
 		resource "tailscale_device_key" "test_key" {
 			device_id = data.tailscale_device.test_device.id
 			key_expiry_disabled = false
@@ -33,10 +33,19 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 		data "tailscale_device" "test_device" {
 			name = "%s"
 		}
-		
+
 		resource "tailscale_device_key" "test_key" {
 			device_id = data.tailscale_device.test_device.id
 			key_expiry_disabled = true
+		}`
+
+	const testDeviceKeyEmpty = `
+		data "tailscale_device" "test_device" {
+			name = "%s"
+		}
+
+		resource "tailscale_device_key" "test_key" {
+			device_id = data.tailscale_device.test_device.id
 		}`
 
 	checkProperties := func(expectExpiryDisabled bool) func(client *tailscale.Client, rs *terraform.ResourceState) error {
@@ -92,6 +101,14 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 					checkResourceRemoteProperties(resourceName, checkProperties(true)),
 					checkResourceRemoteProperties(resourceName, checkLegacyID),
 					resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testDeviceKeyEmpty, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkProperties(false)),
+					checkResourceRemoteProperties(resourceName, checkLegacyID),
+					resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "false"),
 				),
 			},
 			{


### PR DESCRIPTION
Without this patch, we will always get a diff when `key_expiry_disabled` is null, e.g.:

```terraform
resource "tailscale_device_key" "test_key" {
  device_id = data.tailscale_device.test_device.id
  # key_expiry_disabled = true
}
```

Produces this diff on apply every time:

```
  # tailscale_device_key.test_key will be updated in-place
  ~ resource "tailscale_device_key" "test_key" {
      ~ id                  = "1333080874923104" -> (known after apply)
      - key_expiry_disabled = false -> null
        # (1 unchanged attribute hidden)
    }
```

This patch sets a default value of `false` to fix the drift.

Updates tailscale/corp#37032