### PR TITLE
resource_tailnet_settings: use UUID for ID

### DIFF
--- a/tailscale/resource_tailnet_settings.go
+++ b/tailscale/resource_tailnet_settings.go
@@ -193,7 +193,6 @@ func (s *tailnetSettingsResource) readSettings(ctx context.Context, state *tailn
 		return err
 	}
 
-	state.ID = types.StringValue("singleton")
 	state.ACLsExternallyManagedOn = types.BoolValue(settings.ACLsExternallyManagedOn)
 	state.ACLsExternalLink = types.StringValue(settings.ACLsExternalLink)
 	state.DevicesApprovalOn = types.BoolValue(settings.DevicesApprovalOn)
@@ -221,7 +220,6 @@ func (s *tailnetSettingsResource) Create(ctx context.Context, req resource.Creat
 	// create a state with all unknown values so we'll update any fields set in
 	// the plan - and only fields set in the plan.
 	pretendState := tailnetSettingsResourceModel{
-		ID:                                    types.StringUnknown(),
 		ACLsExternallyManagedOn:               types.BoolUnknown(),
 		ACLsExternalLink:                      types.StringUnknown(),
 		DevicesApprovalOn:                     types.BoolUnknown(),
@@ -246,6 +244,7 @@ func (s *tailnetSettingsResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	plan.ID = types.StringValue(createUUID())
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }


### PR DESCRIPTION
Use the UUID function as the ID value for tailnet settings as was being done in the plugin SDKv2.

This seems to be broadly fine from testing, but the Terraform docs mention changing ID formats as a breaking / major version bump change so we are going back to the old format for now.

Updates https://github.com/tailscale/corp/issues/37032
