### PR TITLE
resource_contacts: error if contacts are not set exactly once each

### DIFF
--- a/tailscale/resource_contacts.go
+++ b/tailscale/resource_contacts.go
@@ -6,7 +6,6 @@ package tailscale
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -69,8 +68,7 @@ func (r *contactsResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					},
 				},
 				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.SizeAtMost(1),
+					ExactlyOneBlockRequiredSet(),
 				},
 			},
 			"support": schema.SetNestedBlock{
@@ -84,8 +82,7 @@ func (r *contactsResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					},
 				},
 				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.SizeAtMost(1),
+					ExactlyOneBlockRequiredSet(),
 				},
 			},
 			"security": schema.SetNestedBlock{
@@ -99,8 +96,7 @@ func (r *contactsResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					},
 				},
 				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.SizeAtMost(1),
+					ExactlyOneBlockRequiredSet(),
 				},
 			},
 		},

--- a/tailscale/resource_dns_configuration.go
+++ b/tailscale/resource_dns_configuration.go
@@ -108,7 +108,7 @@ func (r *dnsConfigurationResource) Schema(_ context.Context, _ resource.SchemaRe
 							Description: "Set the nameservers used by devices on your network to resolve DNS queries.",
 
 							Validators: []validator.List{
-								AtLeastOneBlockRequired(),
+								AtLeastOneBlockRequiredList(),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{

--- a/tailscale/validator_test.go
+++ b/tailscale/validator_test.go
@@ -97,7 +97,7 @@ func TestAclHuJSONValidator(t *testing.T) {
 	runStringValidatorTests(t, aclHuJSONValidator{}, testCases)
 }
 
-func TestAtLeastOneBlockRequiredValidator(t *testing.T) {
+func TestAtLeastOneBlockRequiredListValidator(t *testing.T) {
 	const blockName = "blockName"
 	block := types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})
 
@@ -144,7 +144,77 @@ func TestAtLeastOneBlockRequiredValidator(t *testing.T) {
 				Diagnostics: diag.Diagnostics{},
 			}
 
-			atLeastOneBlockRequiredValidator{}.ValidateList(t.Context(), req, &resp)
+			atLeastOneBlockRequiredListValidator{}.ValidateList(t.Context(), req, &resp)
+
+			errors := resp.Diagnostics.Errors()
+			errorCount := len(errors)
+			if tt.wantErr {
+				if errorCount != 1 {
+					t.Errorf("got %d errors, want 1 error", errorCount)
+				} else {
+					gotErr := errors[0]
+					if !strings.Contains(gotErr.Detail(), blockName) {
+						t.Errorf("got error %q, want error to contain %q", gotErr.Detail(), blockName)
+					}
+					if !strings.Contains(gotErr.Summary(), blockName) {
+						t.Errorf("got error %q, want error to contain %q", gotErr.Summary(), blockName)
+					}
+				}
+			} else if errorCount != 0 {
+				t.Errorf("got %d errors, want 0 errors: %v", errorCount, errors)
+			}
+		})
+	}
+}
+
+func TestExactlyOneBlockRequiredSetValidator(t *testing.T) {
+	const blockName = "blockName"
+	block := types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})
+
+	testCases := []struct {
+		name    string
+		config  types.Set
+		wantErr bool
+	}{
+		{
+			name:    "one-block",
+			config:  types.SetValueMust(types.ObjectType{}, []attr.Value{block}),
+			wantErr: false,
+		},
+		{
+			name:    "multiple-blocks",
+			config:  types.SetValueMust(types.ObjectType{}, []attr.Value{block, block}),
+			wantErr: true,
+		},
+		{
+			name:    "no-blocks",
+			config:  types.SetValueMust(types.ObjectType{}, []attr.Value{}),
+			wantErr: true,
+		},
+		{
+			name:    "null",
+			config:  types.SetNull(types.ObjectType{}),
+			wantErr: true,
+		},
+		{
+			name:    "unknown",
+			config:  types.SetUnknown(types.ObjectType{}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.SetRequest{
+				ConfigValue: tt.config,
+				Path:        path.Empty().AtName("parent").AtName(blockName),
+			}
+
+			resp := validator.SetResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			exactlyOneBlockRequiredSetValidator{}.ValidateSet(t.Context(), req, &resp)
 
 			errors := resp.Diagnostics.Errors()
 			errorCount := len(errors)

--- a/tailscale/validators.go
+++ b/tailscale/validators.go
@@ -20,7 +20,8 @@ var (
 	_ validator.String = cidrValidator{}
 	_ validator.String = retryDeadlineValidator{}
 	_ validator.String = aclHuJSONValidator{}
-	_ validator.List   = atLeastOneBlockRequiredValidator{}
+	_ validator.List   = atLeastOneBlockRequiredListValidator{}
+	_ validator.Set    = exactlyOneBlockRequiredSetValidator{}
 )
 
 // cidrValidator is a [validator.String] for CIDR addresses.
@@ -110,22 +111,22 @@ func (v aclHuJSONValidator) ValidateString(ctx context.Context, req validator.St
 	}
 }
 
-// atLeastOneBlockRequiredValidator validates that a list has a configuration
+// atLeastOneBlockRequiredListValidator validates that a list has a configuration
 // value. Intended for use with `schema.ListNestedBlock`.
-type atLeastOneBlockRequiredValidator struct{}
+type atLeastOneBlockRequiredListValidator struct{}
 
 // Description describes the validation in plain text formatting.
-func (v atLeastOneBlockRequiredValidator) Description(_ context.Context) string {
+func (v atLeastOneBlockRequiredListValidator) Description(_ context.Context) string {
 	return "must have at least one nested block configured"
 }
 
 // MarkdownDescription describes the validation in Markdown formatting.
-func (v atLeastOneBlockRequiredValidator) MarkdownDescription(ctx context.Context) string {
+func (v atLeastOneBlockRequiredListValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
 // Validate performs the validation.
-func (v atLeastOneBlockRequiredValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+func (v atLeastOneBlockRequiredListValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
 	len := req.ConfigValue.Length(basetypes.CollectionLengthOptions{
 		UnhandledNullAsZero:    true,
 		UnhandledUnknownAsZero: true,
@@ -138,13 +139,56 @@ func (v atLeastOneBlockRequiredValidator) ValidateList(ctx context.Context, req 
 	}
 }
 
-// AtLeastOneBlockRequired returns a validator which ensures that at least one
+// AtLeastOneBlockRequiredList returns a validator which ensures that at least one
 // instance of the nested block is configured.
 //
 // This validator is similar to the `Required` field on attributes and is only
 // practical for use with `schema.ListNestedBlock`.
 //
 // Unlike [listvalidator.SizeAtLeast] it does not ignore null or unknown values.
-func AtLeastOneBlockRequired() validator.List {
-	return atLeastOneBlockRequiredValidator{}
+func AtLeastOneBlockRequiredList() validator.List {
+	return atLeastOneBlockRequiredListValidator{}
+}
+
+// exactlyOneBlockRequiredSetValidator validates that a set has a configuration
+// value. Intended for use with `schema.SetNestedBlock`.
+type exactlyOneBlockRequiredSetValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v exactlyOneBlockRequiredSetValidator) Description(_ context.Context) string {
+	return "must have exactly one nested block configured"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v exactlyOneBlockRequiredSetValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate performs the validation.
+func (v exactlyOneBlockRequiredSetValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	len := req.ConfigValue.Length(basetypes.CollectionLengthOptions{
+		UnhandledNullAsZero:    true,
+		UnhandledUnknownAsZero: true,
+	})
+	last, _ := req.Path.Steps().LastStep()
+	if len == 0 {
+		resp.Diagnostics.AddAttributeError(req.Path,
+			fmt.Sprintf("No %s block", last),
+			fmt.Sprintf("A %q block is required.", last))
+	} else if len > 1 {
+		resp.Diagnostics.AddAttributeError(req.Path,
+			fmt.Sprintf("Too many %s blocks", last),
+			fmt.Sprintf("Only one %q block is allowed.", last))
+	}
+}
+
+// ExactlyOneBlockRequiredSet returns a validator which ensures that exactly one
+// instance of the nested block is configured.
+//
+// This validator is similar to the `Required` field on attributes and is only
+// practical for use with `schema.SetNestedBlock`.
+//
+// Unlike [setvalidator.SizeAtLeast] it does not ignore null or unknown values.
+func ExactlyOneBlockRequiredSet() validator.Set {
+	return exactlyOneBlockRequiredSetValidator{}
 }


### PR DESCRIPTION
Similar to #755, but a `Set` not a `List`.

Without this patch, the following terraform plans successfully:

```terraform
resource "tailscale_contacts" "test_contacts" {
  account {
    email = "account@example.com"
  }

  support {
    email = "support@example.com"
  }

  # security {
  #   email = "security@example.com"
  # }
}
```

This is not permitted in the previous version of the provider:

```
│ Error: Insufficient security blocks
│
│   on main.tf line 31, in resource "tailscale_contacts" "test_contacts":
│   31: resource "tailscale_contacts" "test_contacts" {
│
│ At least 1 "security" blocks are required.
```

The schema has validators:

```
	Validators: []validator.Set{
		setvalidator.SizeAtLeast(1),
		setvalidator.SizeAtMost(1),
	},
```

But the docs for `SizeAtLeast` explains why this has no effect (same as in #755):

> Null (unconfigured) and unknown (known after apply) values are skipped.

We could use the `listvalidator.IsRequired` validator, which even suggests it's an appropriate validator for the scenario:

```
// This validator is equivalent to the `Required` field on attributes and is only
// practical for use with `schema.ListNestedBlock`
```

But that produces a slightly less helpful error message:

```
│ Error: Invalid Block
│
│   with tailscale_contacts.test_contacts,
│   on main.tf line 31, in resource "tailscale_contacts" "test_contacts":
│   31: resource "tailscale_contacts" "test_contacts" {
│
│ Block security must have a configuration value as the provider has marked it as required
```

Additionally, the error message for supplying too many blocks, rather than not supplying one, also got a little worse. The terraform:

```terraform
resource "tailscale_contacts" "test_contacts" {
  account {
    email = "account@example.com"
  }

  support {
    email = "support@example.com"
  }

  security {
    email = "security1@example.com"
  }

  security {
    email = "security2@example.com"
  }
}
```

On the previous provider results in:

```
│ Error: Too many security blocks
│
│   on main.tf line 44, in resource "tailscale_contacts" "test_contacts":
│   44:   security {
│
│ No more than 1 "security" blocks are allowed
```

But on the latest we get:

```
│ Error: Invalid Attribute Value
│
│   with tailscale_contacts.test_contacts,
│   on main.tf line 31, in resource "tailscale_contacts" "test_contacts":
│   31: resource "tailscale_contacts" "test_contacts" {
│
│ Attribute security set must contain at most 1 elements, got: 2
```

This PR adds a custom validator, `ExactlyOneBlockRequiredSet`, that checks that the provided `SetNestedBlock` is not null and has length exactly 1. If it is not set, or length 0, it produces this error message:

```
│ Error: No security block
│
│   with tailscale_contacts.test_contacts,
│   on main.tf line 31, in resource "tailscale_contacts" "test_contacts":
│   31: resource "tailscale_contacts" "test_contacts" {
│
│ A "security" block is required.
```

And if the length is more than 1, it produces _this_ error message:

```
│ Error: Too many security blocks
│
│   with tailscale_contacts.test_contacts,
│   on main.tf line 31, in resource "tailscale_contacts" "test_contacts":
│   31: resource "tailscale_contacts" "test_contacts" {
│
│ Only one "security" block is allowed.
```

There is a slight quirk where this is allowed:

```terraform
  security {
    email = "security@example.com"
  }

  security {
    email = "security@example.com"
  }
```

Even though this is not:

```
  security {
    email = "security@example.com"
  }

  security {
    email = "security2@example.com" # N.B: this one is different
  }
```

I think this is because it is a `Set` and not a `List` so equal blocks are de-duped?

Updates tailscale/corp#37032