### PR TITLE
resource_acl: validate policy file at plan time

### DIFF
--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -3,14 +3,14 @@ page_title: "tailscale_acl Resource - terraform-provider-tailscale"
 subcategory: ""
 description: |-
   The acl resource allows you to configure a Tailscale policy file. See https://tailscale.com/kb/1395/tailnet-policy-file for more information. Note that this resource will completely overwrite existing policy file contents for a given tailnet.
-  If tests are defined in the policy file (the top-level "tests" section), policy file validation will occur before creation and update operations are applied.
+  The policy file is validated against the Tailscale API during planning, so syntax errors and failing tests (the top-level "tests" section) are surfaced before apply.
 ---
 
 # tailscale_acl (Resource)
 
 The acl resource allows you to configure a Tailscale policy file. See https://tailscale.com/kb/1395/tailnet-policy-file for more information. Note that this resource will completely overwrite existing policy file contents for a given tailnet.
 
-If tests are defined in the policy file (the top-level "tests" section), policy file validation will occur before creation and update operations are applied.
+The policy file is validated against the Tailscale API during planning, so syntax errors and failing tests (the top-level "tests" section) are surfaced before apply.
 
 ~> **Note:** The naming of this resource predates Tailscale's usage of the term "policy file" to refer to the centralized configuration file for a tailnet. This resource controls a tailnet's entire policy file and not just the ACLs section within it.
 

--- a/tailscale/data_source_device_test.go
+++ b/tailscale/data_source_device_test.go
@@ -139,7 +139,7 @@ func TestDeviceRetry_EventualSuccess(t *testing.T) {
 		IsUnitTest: true,
 		PreCheck: func() {
 			// The first response is an error, the second one empty, the third one succeeds.
-			testServer.Responses = []TestResponse{
+			testServer.SetResponses([]TestResponse{
 				{Code: http.StatusInternalServerError, Body: map[string]string{"message": "oh no"}},
 				{Code: http.StatusOK, Body: map[string][]tsclient.Device{
 					"devices": {},
@@ -147,7 +147,7 @@ func TestDeviceRetry_EventualSuccess(t *testing.T) {
 				{Code: http.StatusOK, Body: map[string][]tsclient.Device{
 					"devices": {targetDevice},
 				}},
-			}
+			})
 		},
 		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
@@ -174,9 +174,9 @@ func TestDeviceRetry_PersistentFailure(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
 		PreCheck: func() {
-			testServer.Responses = []TestResponse{
+			testServer.SetResponses([]TestResponse{
 				{Code: http.StatusInternalServerError, Body: map[string]string{"message": "oh no"}},
-			}
+			})
 		},
 		ProtoV5ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -19,6 +20,7 @@ var (
 	_ resource.Resource                = &aclResource{}
 	_ resource.ResourceWithConfigure   = &aclResource{}
 	_ resource.ResourceWithImportState = &aclResource{}
+	_ resource.ResourceWithModifyPlan  = &aclResource{}
 )
 
 type aclResourceModel struct {
@@ -45,7 +47,7 @@ func (r *aclResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 
 const resourceACLDescription = `The acl resource allows you to configure a Tailscale policy file. See https://tailscale.com/kb/1395/tailnet-policy-file for more information. Note that this resource will completely overwrite existing policy file contents for a given tailnet.
 
-If tests are defined in the policy file (the top-level "tests" section), policy file validation will occur before creation and update operations are applied.`
+The policy file is validated against the Tailscale API during planning, so syntax errors and failing tests (the top-level "tests" section) are surfaced before apply.`
 
 // From https://github.com/hashicorp/terraform-plugin-sdk/blob/34d8a9ebca6bed68fddb983123d6fda72481752c/internal/configs/hcl2shim/values.go#L19
 // TODO: use an exported variable when https://github.com/hashicorp/terraform-plugin-sdk/issues/803 has been addressed.
@@ -142,6 +144,33 @@ func (r *aclResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// ModifyPlan validates the planned ACL against the Tailscale API so that
+// syntax errors and failing tests are surfaced at plan time rather than apply.
+func (r *aclResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Nothing to validate when destroying or before the provider is configured.
+	if req.Plan.Raw.IsNull() || r.Client == nil {
+		return
+	}
+
+	var plan aclResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.ACL.IsUnknown() || plan.ACL.IsNull() {
+		return
+	}
+
+	if err := r.Client.PolicyFile().Validate(ctx, plan.ACL.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("acl"),
+			"Invalid ACL",
+			err.Error(),
+		)
+	}
 }
 
 func (r *aclResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -381,3 +381,25 @@ func TestProvider_TailscaleACL_InvalidConfig(t *testing.T) {
 
 	runExpectedErrorTests(t, testCases)
 }
+
+// TestProvider_TailscaleACL_ValidationFailsAtPlan confirms that a policy file
+// rejected by the API's validate endpoint surfaces as an error during plan,
+// before any create or update is attempted.
+func TestProvider_TailscaleACL_ValidationFailsAtPlan(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusBadRequest
+			testServer.ResponseBody = map[string]any{
+				"message": "test for user1@example.com failed",
+			}
+		},
+		ProtoV5ProviderFactories: testProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testACL,
+				ExpectError: regexp.MustCompile(`test for user1@example.com failed`),
+			},
+		},
+	})
+}

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -130,7 +131,17 @@ func TestProvider_TailscaleACLDiffs(t *testing.T) {
 			// Now we check that whitespace changes result in empty plan.
 			{ResourceName: "tailscale_acl.test_acl", Config: toHCL(policyJSON(" ")),
 				PreConfig: func() {
-					testServer.ResponseBody = policyJSON(" ")
+					testServer.HandleRequest = func(method string, path string) TestResponse {
+						if strings.Contains(path, "validate") {
+							return TestResponse{
+								Code: 200,
+							}
+						}
+						return TestResponse{
+							Code: 200,
+							Body: policyJSON("  "),
+						}
+					}
 				},
 			},
 			{ResourceName: "tailscale_acl.test_acl", Config: toHCL(policyJSON("\t"))},
@@ -144,7 +155,17 @@ func TestProvider_TailscaleACLDiffs(t *testing.T) {
 			// Further changes in whitespace are not causing a diff.
 			{ResourceName: "tailscale_acl.test_acl", Config: toHCL(toHuJSON(policyJSON("\t"))),
 				PreConfig: func() {
-					testServer.ResponseBody = toHuJSON(policyJSON("  "))
+					testServer.HandleRequest = func(method string, path string) TestResponse {
+						if strings.Contains(path, "validate") {
+							return TestResponse{
+								Code: 200,
+							}
+						}
+						return TestResponse{
+							Code: 200,
+							Body: toHuJSON(policyJSON("  ")),
+						}
+					}
 				},
 			},
 		},

--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -29,6 +29,8 @@ type TestServer struct {
 	Path   string
 	Body   *bytes.Buffer
 
+	HandleRequest func(method string, path string) TestResponse
+
 	calls     int
 	Responses []TestResponse
 
@@ -41,6 +43,12 @@ func NewTestHarness(t *testing.T) (baseURL string, server *TestServer) {
 
 	testServer := &TestServer{
 		t: t,
+	}
+	testServer.HandleRequest = func(method, path string) TestResponse {
+		return TestResponse{
+			Code: testServer.ResponseCode,
+			Body: testServer.ResponseBody,
+		}
 	}
 
 	mux := http.NewServeMux()
@@ -71,17 +79,7 @@ func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t.Method = r.Method
 	t.Path = r.URL.Path
 
-	var resp TestResponse
-	if len(t.Responses) > 0 {
-		next := min(t.calls, len(t.Responses)-1)
-		t.calls += 1
-		resp = t.Responses[next]
-	} else {
-		resp = TestResponse{
-			Code: t.ResponseCode,
-			Body: t.ResponseBody,
-		}
-	}
+	resp := t.HandleRequest(r.Method, t.Path)
 
 	t.Body = bytes.NewBuffer([]byte{})
 	_, err := io.Copy(t.Body, r.Body)
@@ -99,6 +97,14 @@ func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (t *TestServer) SetResponses(responses []TestResponse) {
 	t.Responses = responses
 	t.calls = 0
+	t.HandleRequest = func(method, path string) TestResponse {
+		if len(t.Responses) > 0 {
+			next := min(t.calls, len(t.Responses)-1)
+			t.calls += 1
+			return t.Responses[next]
+		}
+		return TestResponse{}
+	}
 }
 
 type expectedErrorTestCase struct {


### PR DESCRIPTION
## Summary

- Adds `ModifyPlan` to `tailscale_acl` that calls the policy file Validate API at plan time.
- Updates the resource description accordingly.

Fixes #762.