### PR TITLE
resource_tailnet_key: fix not found handling and key state drift

### DIFF
--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -110,7 +110,7 @@ func (t *tailnetKeyResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional:      true,
 				Computed:      true,
 				Description:   "The expiry of the key in seconds. Defaults to `7776000` (90 days).",
-				PlanModifiers: []planmodifier.Int64{int64planmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.RequiresReplace(), int64planmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Description:   "The creation timestamp of the key in RFC3339 format",
@@ -239,6 +239,8 @@ func (t *tailnetKeyResource) Read(ctx context.Context, req resource.ReadRequest,
 	key, err := t.Client.Keys().Get(ctx, state.ID.ValueString())
 	if tailscale.IsNotFound(err) {
 		state.Invalid = types.BoolValue(true)
+		resp.State.RemoveResource(ctx)
+		return
 	} else if err != nil {
 		resp.Diagnostics.AddError("Failed to fetch key", fmt.Sprintf("Error reading tailnet key with id %q: %s", state.ID, err.Error()))
 		return
@@ -268,7 +270,6 @@ func (t *tailnetKeyResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 	state.Tags = tags
 	state.Preauthorized = types.BoolValue(key.Capabilities.Devices.Create.Preauthorized)
-	state.Key = types.StringValue(key.Key)
 	state.Expiry = types.Int64PointerValue((*int64)(key.ExpirySeconds))
 	state.CreatedAt = types.StringValue(key.Created.Format(time.RFC3339))
 	state.ExpiresAt = types.StringValue(key.Expires.Format(time.RFC3339))
@@ -305,7 +306,6 @@ func (t *tailnetKeyResource) Update(ctx context.Context, req resource.UpdateRequ
 		state.Invalid = types.BoolValue(true)
 	}
 
-	state.Key = types.StringValue(key.Key)
 	state.CreatedAt = types.StringValue(key.Created.Format(time.RFC3339))
 	state.ExpiresAt = types.StringValue(key.Expires.Format(time.RFC3339))
 	state.Description = types.StringValue(key.Description)

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -207,6 +207,17 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 			description = "Test key changed"
 		}`
 
+	const testTailnetKeyUpdateRecreateIfInvalid = `
+		resource "tailscale_tailnet_key" "test_key" {
+			reusable = false
+			ephemeral = false
+			preauthorized = false
+			tags = ["tag:b"]
+			expiry = 7200
+			description = "Test key changed"
+            recreate_if_invalid = "always"
+		}`
+
 	const testTailnetKeyUnsetOptionals = `
 		resource "tailscale_tailnet_key" "test_key" {
 		}`
@@ -302,6 +313,23 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "tags.*", "tag:a"),
 					resource.TestCheckResourceAttr(resourceName, "expiry", "7776000"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test key"),
+					resource.TestCheckResourceAttrSet(resourceName, "key"),
+				),
+			},
+			// Do a re-apply of the existing configuration to ensure that "key" remains set
+			{
+				Config: testTailnetKeyCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties(&expectedKey, 7776000),
+					),
+					resource.TestCheckResourceAttr(resourceName, "reusable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral", "true"),
+					resource.TestCheckResourceAttr(resourceName, "preauthorized", "true"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "tags.*", "tag:a"),
+					resource.TestCheckResourceAttr(resourceName, "expiry", "7776000"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test key"),
+					resource.TestCheckResourceAttrSet(resourceName, "key"),
 				),
 			},
 			{
@@ -321,6 +349,23 @@ func TestAccTailscaleTailnetKey(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "tags.*", "tag:b"),
 					resource.TestCheckResourceAttr(resourceName, "expiry", "7200"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test key changed"),
+					resource.TestCheckResourceAttrSet(resourceName, "key")),
+			},
+			// Ensure that updating "recreate_if_invalid" does not change other properties since it is not a
+			// "force new" operation.
+			{
+				Config: testTailnetKeyUpdateRecreateIfInvalid,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName,
+						checkProperties(&expectedKeyUpdated, 7200),
+					),
+					resource.TestCheckResourceAttr(resourceName, "reusable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral", "false"),
+					resource.TestCheckResourceAttr(resourceName, "preauthorized", "false"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "tags.*", "tag:b"),
+					resource.TestCheckResourceAttr(resourceName, "expiry", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test key changed"),
+					resource.TestCheckResourceAttrSet(resourceName, "key"),
 				),
 			},
 			{


### PR DESCRIPTION
Do a resp.State.RemoveResource call and early return when the key is not
found to properly attempt to recreate the key instead of later running
into a nil pointer.

Remove logic that set the key property in the read and update methods to
prevent state drift of this attribute.

Updates https://github.com/tailscale/terraform-provider-tailscale/issues/764