### PR TITLE
resource_device_key: do nothing on delete

### DIFF
--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -19,6 +19,7 @@ var (
 	_ resource.Resource                = &deviceKeyResource{}
 	_ resource.ResourceWithConfigure   = &deviceKeyResource{}
 	_ resource.ResourceWithImportState = &deviceKeyResource{}
+	_ resource.ResourceWithModifyPlan  = &deviceKeyResource{}
 )
 
 type deviceKeyResourceModel struct {
@@ -94,23 +95,8 @@ func (d deviceKeyResource) Create(ctx context.Context, req resource.CreateReques
 }
 
 func (d deviceKeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var state deviceKeyResourceModel
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	deviceID := state.DeviceID.ValueString()
-	key := tailscale.DeviceKey{}
-
-	if err := d.Client.Devices().SetKey(ctx, deviceID, key); err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to update device key",
-			"Failed to update key for device with ID "+deviceID+": "+err.Error(),
-		)
-		return
-	}
+	// we don't know what key_expiry_disabled was set to before so we can't
+	// restore it, so deletion is a no-op
 }
 
 func (d deviceKeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -177,4 +163,14 @@ func (d deviceKeyResource) Update(ctx context.Context, req resource.UpdateReques
 	plan.ID = types.StringValue(deviceID)
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
+}
+
+func (d deviceKeyResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		resp.Diagnostics.AddWarning(
+			"Resource Destruction Considerations",
+			"Destroying this resource will only remove the resource from the Terraform state and will not undo or change the device's key settings. "+
+				"Use a tailscale_device_key resource to explicitly change the key expiry setting, or manually update it via the admin console.",
+		)
+	}
 }

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -85,7 +85,7 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 		// After delete, device key should revert to its default properties
 		// This is probably not how we actually want things to work, but it's the released behavior.
 		// See https://github.com/tailscale/terraform-provider-tailscale/issues/401.
-		CheckDestroy: checkResourceDestroyed(resourceName, checkProperties(false)),
+		CheckDestroy: checkResourceDestroyed(resourceName, checkProperties(true)),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testDeviceKeyCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
@@ -110,6 +110,26 @@ func TestAccTailscaleDeviceKey(t *testing.T) {
 					checkResourceRemoteProperties(resourceName, checkLegacyID),
 					resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "false"),
 				),
+			},
+			// set it to true again to test what happens on delete
+			{
+				Config: fmt.Sprintf(testDeviceKeyUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkProperties(true)),
+					checkResourceRemoteProperties(resourceName, checkLegacyID),
+					resource.TestCheckResourceAttr(resourceName, "key_expiry_disabled", "true"),
+				),
+			},
+			{
+				Config:  fmt.Sprintf(testDeviceKeyUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
+				Destroy: true,
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceRemoteProperties(resourceName, checkProperties(true)), // should not be changed by destruction
+				),
+			},
+			// recreate it to test import
+			{
+				Config: fmt.Sprintf(testDeviceKeyUpdate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),
 			},
 			{
 				ResourceName:      resourceName,
@@ -198,7 +218,7 @@ func TestAccTailscaleDeviceKey_UsesNodeID(t *testing.T) {
 		// After delete, device key should revert to its default properties
 		// This is probably not how we actually want things to work, but it's the released behavior.
 		// See https://github.com/tailscale/terraform-provider-tailscale/issues/401.
-		CheckDestroy: checkResourceDestroyed(resourceName, checkProperties(false)),
+		CheckDestroy: checkResourceDestroyed(resourceName, checkProperties(true)),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testDeviceKeyCreate, os.Getenv("TAILSCALE_TEST_DEVICE_NAME")),


### PR DESCRIPTION
Fixes #401 by changing deletion to a no-op. Also add a warning about that:

```
│ Warning: Resource Destruction Considerations
│
│ Destroying this resource will only remove the resource from the Terraform state and
│ will not undo or change the device's key settings. Use a tailscale_device_key resource
│ to explicitly change the key expiry setting, or manually update it via the admin
│ console.
```
