### PR TITLE
data_source_device: fix typo in error message

### DIFF
--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -5,7 +5,6 @@ package tailscale
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -112,7 +111,7 @@ func (d singleDeviceDataSource) Read(ctx context.Context, req datasource.ReadReq
 		}
 
 		if len(devices) == 0 {
-			return errors.New("could not find device with" + filterDesc)
+			return fmt.Errorf("could not find device with %s", filterDesc)
 		}
 
 		selected = &devices[0]


### PR DESCRIPTION
If a device isn't found, before:

```
could not find device withname="jamess-macbook-pro-2"
```

after:

```
could not find device with name="jamess-macbook-pro-2"
```
